### PR TITLE
Renamed AD Users & Request Offering Matches

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -20,6 +20,8 @@ Requires: PowerShell 4+, SMlets, and Exchange Web Services API (already installe
     Signged/Encrypted option: .NET 4.5 is required to use MimeKit.dll
 Misc: The Release Record functionality does not exist in this as no out of box (or 3rd party) Type Projection exists to serve this purpose.
     You would have to create your own Type Projection in order to leverage this.
+Version: 1.3.1 = Fixed issue matching users when AD connector syncs users that were renamed.
+                Changed how Request Offering suggestions are matched and made.
 Version: 1.3 = created Set-CiresonPortalAnnouncement and Set-CoreSCSMAnnouncement to introduce announcement integration into the connector
                     by leveraging the new configurable [announcement] keyword and #low or #high tags to set priority on the announcement.
                     absence of the tag results in a normal priority announcement being created


### PR DESCRIPTION
BUG: Addressing a shortcoming of the native SCSM AD connector wherein a renamed users creates a wholly new user object. If the email address/notification channel is the same for that user two SMTP channels will be found for two users resulting in subsequent failures of correctly identifying Affected/Related users. This accounts for an issue where occasionally a New Work Item is missing the Affected User.

CHANGE: Improved how Request Offerings matches are determined. Added new configurable variable $numberOfWordsToMatchFromEmailToRO to allow deployments to define the minimum number of words that must be matched on the incoming email/new work item before suggesting Request Offerings available to that user within their security scope. By default this value is set to 1 to ensure at least some level of matching occurs.

MISC: Added notes to be more descriptive of configuration