### PR TITLE
Explicit declaration of name parameter on Get-SCSMClass

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -20,6 +20,7 @@ Requires: PowerShell 4+, SMlets, and Exchange Web Services API (already installe
     Signged/Encrypted option: .NET 4.5 is required to use MimeKit.dll
 Misc: The Release Record functionality does not exist in this as no out of box (or 3rd party) Type Projection exists to serve this purpose.
     You would have to create your own Type Projection in order to leverage this.
+Version: 1.3.2 = Fixed issue when using the script other than on the SCSM Workflow server
 Version: 1.3.1 = Fixed issue matching users when AD connector syncs users that were renamed.
                 Changed how Request Offering suggestions are matched and made.
 Version: 1.3 = created Set-CiresonPortalAnnouncement and Set-CoreSCSMAnnouncement to introduce announcement integration into the connector
@@ -192,47 +193,47 @@ $mimeKitDLLPath = "c:\smletsExchangeConnector\mimekit.dll"
 #endregion
 
 #region #### SCSM Classes ####
-$irClass = get-scsmclass "System.WorkItem.Incident$" -computername $scsmMGMTServer
-$srClass = get-scsmclass "System.WorkItem.ServiceRequest$" -computername $scsmMGMTServer
-$prClass = get-scsmclass "System.WorkItem.Problem$" -computername $scsmMGMTServer
-$crClass = get-scsmclass "System.Workitem.ChangeRequest$" -computername $scsmMGMTServer
-$rrClass = get-scsmclass "System.Workitem.ReleaseRecord$" -computername $scsmMGMTServer
-$maClass = get-scsmclass "System.WorkItem.Activity.ManualActivity$" -computername $scsmMGMTServer
-$raClass = get-scsmclass "System.WorkItem.Activity.ReviewActivity$" -computername $scsmMGMTServer
-$paClass = get-scsmclass "System.WorkItem.Activity.ParallelActivity$" -computername $scsmMGMTServer
-$saClass = get-scsmclass "System.WorkItem.Activity.SequentialActivity$" -computername $scsmMGMTServer
-$daClass = get-scsmclass "System.WorkItem.Activity.DependentActivity$" -computername $scsmMGMTServer
+$irClass = get-scsmclass -name "System.WorkItem.Incident$" -computername $scsmMGMTServer
+$srClass = get-scsmclass -name "System.WorkItem.ServiceRequest$" -computername $scsmMGMTServer
+$prClass = get-scsmclass -name "System.WorkItem.Problem$" -computername $scsmMGMTServer
+$crClass = get-scsmclass -name "System.Workitem.ChangeRequest$" -computername $scsmMGMTServer
+$rrClass = get-scsmclass -name "System.Workitem.ReleaseRecord$" -computername $scsmMGMTServer
+$maClass = get-scsmclass -name "System.WorkItem.Activity.ManualActivity$" -computername $scsmMGMTServer
+$raClass = get-scsmclass -name "System.WorkItem.Activity.ReviewActivity$" -computername $scsmMGMTServer
+$paClass = get-scsmclass -name "System.WorkItem.Activity.ParallelActivity$" -computername $scsmMGMTServer
+$saClass = get-scsmclass -name "System.WorkItem.Activity.SequentialActivity$" -computername $scsmMGMTServer
+$daClass = get-scsmclass -name "System.WorkItem.Activity.DependentActivity$" -computername $scsmMGMTServer
 
-$raHasReviewerRelClass = Get-SCSMRelationshipClass "System.ReviewActivityHasReviewer$" -computername $scsmMGMTServer
-$raReviewerIsUserRelClass = Get-SCSMRelationshipClass "System.ReviewerIsUser$" -computername $scsmMGMTServer
-$raVotedByUserRelClass = Get-SCSMRelationshipClass "System.ReviewerVotedByUser$" -computername $scsmMGMTServer
+$raHasReviewerRelClass = Get-SCSMRelationshipClass -name "System.ReviewActivityHasReviewer$" -computername $scsmMGMTServer
+$raReviewerIsUserRelClass = Get-SCSMRelationshipClass -name "System.ReviewerIsUser$" -computername $scsmMGMTServer
+$raVotedByUserRelClass = Get-SCSMRelationshipClass -name "System.ReviewerVotedByUser$" -computername $scsmMGMTServer
 
-$userClass = get-scsmclass "System.User$" -computername $scsmMGMTServer
-$domainUserClass = get-scsmclass "System.Domain.User$" -computername $scsmMGMTServer
-$notificationClass = get-scsmclass "System.Notification.Endpoint$" -computername $scsmMGMTServer
+$userClass = get-scsmclass -name "System.User$" -computername $scsmMGMTServer
+$domainUserClass = get-scsmclass -name "System.Domain.User$" -computername $scsmMGMTServer
+$notificationClass = get-scsmclass -name "System.Notification.Endpoint$" -computername $scsmMGMTServer
 
-$irLowImpact = Get-SCSMEnumeration "System.WorkItem.TroubleTicket.ImpactEnum.Low$" -computername $scsmMGMTServer
-$irLowUrgency = Get-SCSMEnumeration "System.WorkItem.TroubleTicket.ImpactEnum.Low$" -computername $scsmMGMTServer
-$irActiveStatus = Get-SCSMEnumeration "IncidentStatusEnum.Active$" -computername $scsmMGMTServer
+$irLowImpact = Get-SCSMEnumeration -name "System.WorkItem.TroubleTicket.ImpactEnum.Low$" -computername $scsmMGMTServer
+$irLowUrgency = Get-SCSMEnumeration -name "System.WorkItem.TroubleTicket.ImpactEnum.Low$" -computername $scsmMGMTServer
+$irActiveStatus = Get-SCSMEnumeration -name "IncidentStatusEnum.Active$" -computername $scsmMGMTServer
 
-$affectedUserRelClass = get-scsmrelationshipclass "System.WorkItemAffectedUser$" -computername $scsmMGMTServer
-$assignedToUserRelClass  = Get-SCSMRelationshipClass "System.WorkItemAssignedToUser$" -computername $scsmMGMTServer
-$createdByUserRelClass = Get-SCSMRelationshipClass "System.WorkItemCreatedByUser$" -computername $scsmMGMTServer
-$workResolvedByUserRelClass = Get-SCSMRelationshipClass "System.WorkItem.TroubleTicketResolvedByUser$" -computername $scsmMGMTServer
-$wiRelatesToCIRelClass = Get-SCSMRelationshipClass "System.WorkItemRelatesToConfigItem$" -computername $scsmMGMTServer
-$wiRelatesToWIRelClass = Get-SCSMRelationshipClass "System.WorkItemRelatesToWorkItem$" -computername $scsmMGMTServer
-$wiContainsActivityRelClass = Get-SCSMRelationshipClass "System.WorkItemContainsActivity$" -computername $scsmMGMTServer
-$sysUserHasPrefRelClass = Get-SCSMRelationshipClass "System.UserHasPreference$" -ComputerName $scsmMGMTServer
+$affectedUserRelClass = get-scsmrelationshipclass -name "System.WorkItemAffectedUser$" -computername $scsmMGMTServer
+$assignedToUserRelClass  = Get-SCSMRelationshipClass -name "System.WorkItemAssignedToUser$" -computername $scsmMGMTServer
+$createdByUserRelClass = Get-SCSMRelationshipClass -name "System.WorkItemCreatedByUser$" -computername $scsmMGMTServer
+$workResolvedByUserRelClass = Get-SCSMRelationshipClass -name "System.WorkItem.TroubleTicketResolvedByUser$" -computername $scsmMGMTServer
+$wiRelatesToCIRelClass = Get-SCSMRelationshipClass -name "System.WorkItemRelatesToConfigItem$" -computername $scsmMGMTServer
+$wiRelatesToWIRelClass = Get-SCSMRelationshipClass -name "System.WorkItemRelatesToWorkItem$" -computername $scsmMGMTServer
+$wiContainsActivityRelClass = Get-SCSMRelationshipClass -name "System.WorkItemContainsActivity$" -computername $scsmMGMTServer
+$sysUserHasPrefRelClass = Get-SCSMRelationshipClass -name "System.UserHasPreference$" -ComputerName $scsmMGMTServer
 
 $fileAttachmentClass = Get-SCSMClass -Name "System.FileAttachment$" -computername $scsmMGMTServer
-$fileAttachmentRelClass = Get-SCSMRelationshipClass "System.WorkItemHasFileAttachment$" -computername $scsmMGMTServer
-$fileAddedByUserRelClass = Get-SCSMRelationshipClass "System.FileAttachmentAddedByUser$" -ComputerName $scsmMGMTServer
+$fileAttachmentRelClass = Get-SCSMRelationshipClass -name "System.WorkItemHasFileAttachment$" -computername $scsmMGMTServer
+$fileAddedByUserRelClass = Get-SCSMRelationshipClass -name "System.FileAttachmentAddedByUser$" -ComputerName $scsmMGMTServer
 $managementGroup = New-Object Microsoft.EnterpriseManagement.EnterpriseManagementGroup $scsmMGMTServer
 
-$irTypeProjection = Get-SCSMTypeProjection "system.workitem.incident.projectiontype$" -computername $scsmMGMTServer
-$srTypeProjection = Get-SCSMTypeProjection "system.workitem.servicerequestprojection$" -computername $scsmMGMTServer
+$irTypeProjection = Get-SCSMTypeProjection -name "system.workitem.incident.projectiontype$" -computername $scsmMGMTServer
+$srTypeProjection = Get-SCSMTypeProjection -name "system.workitem.servicerequestprojection$" -computername $scsmMGMTServer
 
-$userHasPrefProjection = Get-SCSMTypeProjection "System.User.Preferences.Projection$" -computername $scsmMGMTServer
+$userHasPrefProjection = Get-SCSMTypeProjection -name "System.User.Preferences.Projection$" -computername $scsmMGMTServer
 #endregion
 
 #region #### Exchange Connector Functions ####

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -21,6 +21,7 @@ Requires: PowerShell 4+, SMlets, and Exchange Web Services API (already installe
 Misc: The Release Record functionality does not exist in this as no out of box (or 3rd party) Type Projection exists to serve this purpose.
     You would have to create your own Type Projection in order to leverage this.
 Version: 1.3.2 = Fixed issue when using the script other than on the SCSM Workflow server
+                 Fixed issue when enabling/disabling features
 Version: 1.3.1 = Fixed issue matching users when AD connector syncs users that were renamed.
                 Changed how Request Offering suggestions are matched and made.
 Version: 1.3 = created Set-CiresonPortalAnnouncement and Set-CoreSCSMAnnouncement to introduce announcement integration into the connector
@@ -1824,7 +1825,14 @@ if ($processEncryptedMessages -eq $true)
 
 #finalize the where-object string by ensuring to look for all Unread Items
 $inboxFilterString = $inboxFilterString -join ' -or '
-$inboxFilterString = "(" + $inboxFilterString + " -or " +  $emailFilterString + ")" + " -and " + $unreadFilterString
+if ($inboxFilterString.length -eq 0)
+{
+    $inboxFilterString = "(" + $emailFilterString + ")" + " -and " + $unreadFilterString
+}
+else 
+{
+    $inboxFilterString = "(" + $inboxFilterString + " -or " + $emailFilterString + ")" + " -and " + $unreadFilterString
+}
 $inboxFilterString = [scriptblock]::Create("$inboxFilterString")
 
 #filter the inbox

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1,15 +1,6 @@
 ﻿<#
 .SYNOPSIS
-Provides SCSM Exchange Connector functionality through PoPortalAnnouncement and Set-CoreSCSMAnnouncement to introduce announcement integration into the connector
-                    by leveraging the new configurable [announcement] keyword and #low or #high tags to set priority on the announcement.
-                    absence of the tag results in a normal priority announcement being created
-                created Get-SCSMAuthorizedAnnouncer to verify the sender's permissions to post announcements
-                created Get-CiresonPortalAnnouncements to search/update announcements
-                created Read-MIMEMessage to allow parsing digitally signed or encryped emails. This feature leverages the
-                    open source project known as MimeKit by Jeffrey Stedfast. It can be found here - https://github.com/jstedfast/MimeKit   
-                created Get-CiresonPortalUser to query for a user through the Cireson Web API to retrieve user information (object)
-                created Get-CiresonPortalGroup to query for a group through the Cireson Web API to retrieve group information (object)                          
-                created Search-AwerShell
+Provides SCSM Exchange Connector functionality through PowerShell
 
 .DESCRIPTION
 This PowerShell script/runbook aims to address shortcomings and wants in the
@@ -32,7 +23,16 @@ Misc: The Release Record functionality does not exist in this as no out of box (
 Version: 1.3.2 = Fixed issue when using the script other than on the SCSM Workflow server
 Version: 1.3.1 = Fixed issue matching users when AD connector syncs users that were renamed.
                 Changed how Request Offering suggestions are matched and made.
-Version: 1.3 = created Set-CiresonvailableCiresonPortalOfferings in order to look for relevant request offerings within a user's
+Version: 1.3 = created Set-CiresonPortalAnnouncement and Set-CoreSCSMAnnouncement to introduce announcement integration into the connector
+                    by leveraging the new configurable [announcement] keyword and #low or #high tags to set priority on the announcement.
+                    absence of the tag results in a normal priority announcement being created
+                created Get-SCSMAuthorizedAnnouncer to verify the sender's permissions to post announcements
+                created Get-CiresonPortalAnnouncements to search/update announcements
+                created Read-MIMEMessage to allow parsing digitally signed or encryped emails. This feature leverages the
+                    open source project known as MimeKit by Jeffrey Stedfast. It can be found here - https://github.com/jstedfast/MimeKit   
+                created Get-CiresonPortalUser to query for a user through the Cireson Web API to retrieve user information (object)
+                created Get-CiresonPortalGroup to query for a group through the Cireson Web API to retrieve group information (object)                          
+                created Search-AvailableCiresonPortalOfferings in order to look for relevant request offerings within a user's
                     Service Catalog scope to suggest relevant requests to the Affected User based on the content of their email           
                 improved/simplified Search-CiresonKnowledgeBase by use of new Get-CiresonPortalUser function              
                 created Get-SCOMDistributedAppHealth (SCOM integration) allows an authorized user to retrieve the health of


### PR DESCRIPTION
ISSUE: Get-SCSMClass sometimes fails to identify the class. This can be experienced when the script is running somewhere other than the workflow server. Explicitly calling out the name parameter fixes this.

ISSUE: Missing "computername" parameter in several spots. Problematic when this isn't running on the workflow server.

BUG: When enabling/disabling features the [scriptblock] can become malformed.

NOTE: With previous Pull Request, incorrectly named the branch. Closed the pull, deleted the branch, re-did the pull with the correctly named branch of 1.3.2
