### PR TITLE
Change Incident Status on reply

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -163,11 +163,11 @@ $ExchangeEndpoint = ""
     #The PII being redacted is listed as regex's in a text file located in the same directory as the script. The file is called "pii_regex.txt", has 1 regex per line, written without quotes.
 #changeIncidentStatusOnReply = if $true, updates to Incidents will change their status based on who replied
 #changeIncidentStatusOnReplyAffectedUser = If changeIncidentStatusOnReply is $true, the Status enum an Incident should change to when the Affected User updates the Incident via email
-    #perform a: Get-SCSMEnumeration -name "MA Support Group List name" to verify your Incident Status enum value if not using the out of box enums
+    #perform a: Get-SCSMEnumeration -name "Incident Status enum name" to verify your Incident Status enum value if not using the out of box enums
 #changeIncidentStatusOnReplyAssignedTo = If changeIncidentStatusOnReply is $true, The Status enum an Incident should change to when the Assigned To updates the Incident via email
-    #perform a: Get-SCSMEnumeration -name "MA Support Group List name" to verify your Incident Status enum value if not using the out of box enums
+    #perform a: Get-SCSMEnumeration -name "Incident Status enum name" to verify your Incident Status enum value if not using the out of box enums
 #changeIncidentStatusOnReplyRelatedUser = If changeIncidentStatusOnReply is $true, The Status enum an Incident should change to when a Related User updates the Incident via email
-    #perform a: Get-SCSMEnumeration -name "MA Support Group List name" to verify your Incident Status enum value if not using the out of box enums
+    #perform a: Get-SCSMEnumeration -name "Incident Status enum name" to verify your Incident Status enum value if not using the out of box enums
 $defaultNewWorkItem = "ir"
 $defaultIRTemplateName = "IR Template Name Goes Here"
 $defaultSRTemplateName = "SR Template Name Goes Here"

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -163,11 +163,14 @@ $ExchangeEndpoint = ""
     #The PII being redacted is listed as regex's in a text file located in the same directory as the script. The file is called "pii_regex.txt", has 1 regex per line, written without quotes.
 #changeIncidentStatusOnReply = if $true, updates to Incidents will change their status based on who replied
 #changeIncidentStatusOnReplyAffectedUser = If changeIncidentStatusOnReply is $true, the Status enum an Incident should change to when the Affected User updates the Incident via email
-    #perform a: Get-SCSMEnumeration -name "Incident Status enum name" to verify your Incident Status enum value if not using the out of box enums
+    #perform a: Get-SCSMChildEnumeration -Enumeration (Get-SCSMEnumeration -name "IncidentStatusEnum$") | Where-Object {$_.displayname -eq "myCustomStatusHere"}
+    #to verify your Incident Status enum value Name if not using the out of box enums
 #changeIncidentStatusOnReplyAssignedTo = If changeIncidentStatusOnReply is $true, The Status enum an Incident should change to when the Assigned To updates the Incident via email
-    #perform a: Get-SCSMEnumeration -name "Incident Status enum name" to verify your Incident Status enum value if not using the out of box enums
+    #perform a: Get-SCSMChildEnumeration -Enumeration (Get-SCSMEnumeration -name "IncidentStatusEnum$") | Where-Object {$_.displayname -eq "myCustomStatusHere"}
+    #to verify your Incident Status enum value Name if not using the out of box enums
 #changeIncidentStatusOnReplyRelatedUser = If changeIncidentStatusOnReply is $true, The Status enum an Incident should change to when a Related User updates the Incident via email
-    #perform a: Get-SCSMEnumeration -name "Incident Status enum name" to verify your Incident Status enum value if not using the out of box enums
+    #perform a: Get-SCSMChildEnumeration -Enumeration (Get-SCSMEnumeration -name "IncidentStatusEnum$") | Where-Object {$_.displayname -eq "myCustomStatusHere"}
+    #to verify your Incident Status enum value Name if not using the out of box enums
 $defaultNewWorkItem = "ir"
 $defaultIRTemplateName = "IR Template Name Goes Here"
 $defaultSRTemplateName = "SR Template Name Goes Here"


### PR DESCRIPTION
Per discussion within #91 the first implementation of this feature this introduces a new configuration variable, three "status to change to" style variables, and eventually their implementation within the Update-WorkItem's respective User switch actions.

By introducing this feature:
- organizations can more accurately report against the time an Incident is within a respective Status
- analysts can better manage their respective work queues
- complement [Cireson's Notify Analyst](https://cireson.com/apps/notify-analyst-community-free/) functionality
- complement [Cireson's Analyst Portal Send Email feature](https://cireson.com/apps/analyst-portal/) functionality wherein Analyst can mark an Incident as "Pending" on send