### PR TITLE
Multi-mailbox enhancement when Inbox is part of a Distribution Group

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3119,7 +3119,14 @@ foreach ($message in $inbox)
     {
         $email = New-Object System.Object 
         $email | Add-Member -type NoteProperty -name From -value $message.From.Address
-        $email | Add-Member -type NoteProperty -name To -value $message.ToRecipients
+        if ($message.ReceivedBy -ne $NULL)
+        {
+            $email | Add-Member -type NoteProperty -name To -value $message.ReceivedBy
+        }
+        else
+        {
+            $email | Add-Member -type NoteProperty -name To -value $message.ToRecipients
+        }
         $email | Add-Member -type NoteProperty -name CC -value $message.CcRecipients
         $email | Add-Member -type NoteProperty -name Subject -value $message.Subject
         $email | Add-Member -type NoteProperty -name Attachments -value $message.Attachments


### PR DESCRIPTION
Added logic to detect when ToRecipients and ReceivedBy fields are different. If different, use the ReceivedBy field. See referenced issue below for details.

https://github.com/AdhocAdam/smletsexchangeconnector/issues/141