### PR TITLE
Multi-mailbox enhancement when Inbox is part of a Distribution Group - Logic for ReceivedBy property

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3234,7 +3234,14 @@ foreach ($message in $inbox)
     {
         $email = New-Object System.Object 
         $email | Add-Member -type NoteProperty -name From -value $message.From.Address
-        $email | Add-Member -type NoteProperty -name To -value $message.ToRecipients
+        if ($message.ReceivedBy -ne $message.ToRecipients)
+        {
+            $email | Add-Member -type NoteProperty -name To -value $message.ReceivedBy
+        }
+        else
+        {
+            $email | Add-Member -type NoteProperty -name To -value $message.ToRecipients
+        }
         $email | Add-Member -type NoteProperty -name CC -value $message.CcRecipients
         $email | Add-Member -type NoteProperty -name Subject -value $message.Subject
         $email | Add-Member -type NoteProperty -name Attachments -value $message.Attachments


### PR DESCRIPTION
Added logic for ReceivedBy property. Did not change sections for the encrypted or digitally signed messages as we don't use  those in our environment. Should just be a copy/paste from the modified sections to those areas to apply the same fix. Since the ReceivedBy property is always set and is almost always going to be the mailbox used for receiving the message, it might be ideal to just use the ReceivedBy property in place of the ToRecipients, though I haven't done much thinking on this so my logic may be flawed.