### PR TITLE
Sanitizing language input

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2842,7 +2842,7 @@ function Get-AzureEmailLanguage ($TextToEvaluate)
     $translationServiceURI = "https://api.cognitive.microsofttranslator.com/detect?api-version=3.0"
     $RecoRequestHeader = @{
       'Ocp-Apim-Subscription-Key' = "$azureCogSvcTranslateAPIKey";
-      'Content-Type' = "application/json"
+      'Content-Type' = "application/json; charset=utf-8"
     }
 
     #prepare the body of the request
@@ -2864,7 +2864,7 @@ function Get-AzureEmailTranslation ($TextToTranslate, $SourceLanguage, $TargetLa
     $translationServiceURI = "https://api.cognitive.microsofttranslator.com/translate?api-version=3.0&from=$($SourceLanguage)&to=$($TargetLanguage)"
     $RecoRequestHeader = @{
       'Ocp-Apim-Subscription-Key' = "$azureCogSvcTranslateAPIKey";
-      'Content-Type' = "application/json"
+      'Content-Type' = "application/json; charset=utf-8"
     }
 
     #prepare the body of the request


### PR DESCRIPTION
If a language is used with certain types of characters, it's possible that the translate functions break when they encounter the character. To get around this, strings will be UTF-8 encoded similar to the very nature of the translate API.

Also introducing handling for a condition when the Detected Language scores identical confidence to the top Alternative Detected Language. In this case, there is a possibility that translation doesn't occur because the Detected Language is the default target language that was configured in the connector. Take the following example:

- A message comes in that features a fairly equal amount of Spanish and English. Azure Translate detects English and then doesn't translate because English is the default language to translate into. However the top Detected Alternative Language is Spanish. If this were used, then translation would occur.