### PR TITLE
Support Group extension fix

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -570,15 +570,15 @@ $userHasPrefProjection = Get-SCSMTypeProjection -name "System.User.Preferences.P
 # Retrieve Class Extensions on IR/SR/CR/MA if defined
 if ($maSupportGroupEnumGUID)
 {
-    $maSupportGroupPropertyName = ($maClass.GetProperties(1, 1) | where-object {($_.SystemType.Name -eq "Enum") -and ($_.EnumType -like "*$maSupportGroupEnumGUID*")}).Name
+    $maSupportGroupPropertyName = ($maClass.GetProperties(1, 1) | where-object {($_.SystemType.Name -eq "Enum") -and ($_.Id -like "*$maSupportGroupEnumGUID*")}).Name
 }
 if ($crSupportGroupEnumGUID)
 {
-    $crSupportGroupPropertyName = ($crClass.GetProperties(1, 1) | where-object {($_.SystemType.Name -eq "Enum") -and ($_.EnumType -like "*$crSupportGroupEnumGUID*")}).Name
+    $crSupportGroupPropertyName = ($crClass.GetProperties(1, 1) | where-object {($_.SystemType.Name -eq "Enum") -and ($_.Id -like "*$crSupportGroupEnumGUID*")}).Name
 }
 if ($prSupportGroupEnumGUID)
 {
-    $prSupportGroupPropertyName = ($prClass.GetProperties(1, 1) | where-object {($_.SystemType.Name -eq "Enum") -and ($_.EnumType -like "*$prSupportGroupEnumGUID*")}).Name
+    $prSupportGroupPropertyName = ($prClass.GetProperties(1, 1) | where-object {($_.SystemType.Name -eq "Enum") -and ($_.Id -like "*$prSupportGroupEnumGUID*")}).Name
 }
 #azure cognitive services
 if ($acsSentimentScoreIRClassExtensionName)


### PR DESCRIPTION
How the class extension for support group is found on MA, CR, and PR classes uses a different property name compared to v1