### PR TITLE
fix, MA non-Implementer action (v2.x)

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1751,13 +1751,7 @@ function Update-WorkItem ($message, $wiType, $workItemID) 
                                     }
                                 }
                                 default {
-                                    $parentWorkItem = Get-SCSMWorkItemParent $workItem.Get_Id().Guid
-                                    switch ($parentWorkItem.Classname)
-                                    {
-                                        "System.WorkItem.ChangeRequest" {Add-ActionLogEntry -WIObject $parentWorkItem -Comment $commentToAdd -EnteredBy $commentLeftBy -Action "EndUserComment" -IsPrivate $false}
-                                        "System.WorkItem.ServiceRequest" {Add-ActionLogEntry -WIObject $parentWorkItem -Comment $commentToAdd -EnteredBy $commentLeftBy -Action "EndUserComment" -IsPrivate $false}
-                                        "System.WorkItem.Incident" {Add-ActionLogEntry -WIObject $parentWorkItem -Comment $commentToAdd -EnteredBy $commentLeftBy -Action "EndUserComment" -IsPrivate $false}
-                                    }
+                                    Set-SCSMObject -SMObject $workItem -PropertyHashtable @{"Notes" = "$($workItem.Notes)$($activityImplementer.Name) @ $(get-date): $commentToAdd `n"} @scsmMGMTParams
                                 }
                             } 
                         }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1751,7 +1751,7 @@ function Update-WorkItem ($message, $wiType, $workItemID) 
                                     }
                                 }
                                 default {
-                                    Set-SCSMObject -SMObject $workItem -PropertyHashtable @{"Notes" = "$($workItem.Notes)$($activityImplementer.Name) @ $(get-date): $commentToAdd `n"} @scsmMGMTParams
+                                    Set-SCSMObject -SMObject $workItem -PropertyHashtable @{"Notes" = "$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n"} @scsmMGMTParams
                                 }
                             } 
                         }


### PR DESCRIPTION
This is to preserve functionality in Update-WorkItem for Manual Activities when the comment to add is not from the Activity Implementer and features no keywords. The comment should be added to the MA Notes, rather than the Parent Work Item.