### PR TITLE
multi-mailbox logic check (2.x)

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -771,7 +771,10 @@ function New-WorkItem ($message, $wiType, $returnWIBool) 
         }
     }
     
-    $TemplatesForThisMessage = Get-TemplatesByMailbox $message
+    if (($smexcoSettingsMP.UseMailboxRedirection -eq $true) -and ($smexcoSettingsMPMailboxes.Count -ge 1))
+    {
+        $TemplatesForThisMessage = Get-TemplatesByMailbox $message
+    }
     
     # Use the global default work item type or, if mailbox redirection is used, use the default work item type for the
     # specific mailbox that the current message was sent to. If Azure Cognitive Services is enabled


### PR DESCRIPTION
When the multi-mailbox feature isn't used PowerShell will throw errors around the feature. Rather than immediately test for the templates, this wraps a quick logic check into the New-WorkItem function.