### PR TITLE
Multi-Mailbox default mailbox variable (v1.x)

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2563,7 +2563,7 @@ function Get-TemplatesByMailbox ($message)
             }
             else {
                 Write-Debug "No redirection from known mailbox.  Using Default templates"
-                return $Mailboxes[$ScsmEmail]
+                return $Mailboxes[$workflowEmailAddress]
             }
         }
     }


### PR DESCRIPTION
In the Get-TemplatesByMailbox function, when no redirection from a known mailbox can be found the incorrect variable was used.