### PR TITLE
fix, Dynamic Analyst Assignment sort order (v2.x)

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2085,11 +2085,11 @@ function Set-AssignedToPerSupportGroup ($SupportGroupID, $WorkItem)
         #based on how Dynamic Work Item assignment was configured, set the Assigned To User
         if ($DynamicWorkItemAssignment -eq "volume")
         {
-            $userToAssign = $supportGroupMembers | foreach-object {Get-AssignedToWorkItemVolume -SCSMUser $_} | Sort-Object AssignedCount -Descending | Select-Object SCSMUser -ExpandProperty SCSMUser -first 1 
+            $userToAssign = $supportGroupMembers | foreach-object {Get-AssignedToWorkItemVolume -SCSMUser $_} | Sort-Object AssignedCount | Select-Object SCSMUser -ExpandProperty SCSMUser -first 1 
         }
         elseif ($DynamicWorkItemAssignment -eq "OOOvolume")
         {
-            $userToAssign = $supportGroupMembers | Where-Object {$_.OutOfOffice -ne $true} | foreach-object {Get-AssignedToWorkItemVolume -SCSMUser $_} | Sort-Object AssignedCount -Descending | Select-Object SCSMUser -ExpandProperty SCSMUser -first 1
+            $userToAssign = $supportGroupMembers | Where-Object {$_.OutOfOffice -ne $true} | foreach-object {Get-AssignedToWorkItemVolume -SCSMUser $_} | Sort-Object AssignedCount | Select-Object SCSMUser -ExpandProperty SCSMUser -first 1
         }
         elseif ($DynamicWorkItemAssignment -eq "random")
         {


### PR DESCRIPTION
Made a change to the Set-AssignedToPerSupportGroup function to address a small bug which selected the Analyst with the highest assigned Work Item count, rather than the lowest.