### PR TITLE
Code citation realignment (v2.x)

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3165,8 +3165,6 @@ function Get-AzureEmailKeywords ($messageToEvaluate)
 }
 #endregion
 
-#region #### Modified version of Set-SCSMTemplateWithActivities from Morton Meisler seen here http://blog.ctglobalservices.com/service-manager-scsm/mme/set-scsmtemplatewithactivities-powershell-script/
-
 function Get-AMLWorkItemProbability ($EmailSubject, $EmailBody)
 {
     #create the header
@@ -3206,6 +3204,7 @@ function Get-AMLWorkItemProbability ($EmailSubject, $EmailBody)
     return ($probabilityMatrix)
 }
 
+#region #### Modified version of Set-SCSMTemplateWithActivities from Morton Meisler seen here http://blog.ctglobalservices.com/service-manager-scsm/mme/set-scsmtemplatewithactivities-powershell-script/
 function Update-SCSMPropertyCollection
 {
     Param ([Microsoft.EnterpriseManagement.Configuration.ManagementPackObjectTemplateObject]$Object =$(throw "Please provide a valid template object")) 
@@ -3256,6 +3255,7 @@ function Apply-SCSMTemplate
     #Apply update template
     Set-SCSMObjectTemplate -Projection $Projection -Template $Template -ErrorAction Stop @scsmMGMTParams
 }
+#endregion
 
 function Remove-PII ($body)
 {
@@ -3276,8 +3276,6 @@ function Remove-PII ($body)
     }
     return $body
 }
-
-#endregion 
 
 #region #### SCOM Request Functions ####
 function Get-SCOMAuthorizedRequester ($sender)


### PR DESCRIPTION
Realigning the Apply Template code region with proper citation as somewhere along the way it was referencing the wrong region of code