### PR TITLE
Autodiscover URL textbox availability

### DIFF
--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/GeneralSettingsForm.xaml
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/GeneralSettingsForm.xaml
@@ -19,7 +19,7 @@
                 <TextBox Height="25" Margin="10,0,10,10" x:Name="txtSCSMmgmtServer" Text="{Binding SCSMmanagementServer, Mode=TwoWay}" />
                 <TextBlock Margin="10,0,0,0" x:Name="lblWFEmailAddress" TextWrapping="Wrap" Text="Workflow Email Address" />
                 <TextBox Height="25" Margin="10,0,10,10" x:Name="txtWFEmailAddress" Text="{Binding WorkflowEmailAddress, Mode=TwoWay}" Custom:Validation.RegexPattern="^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,9})$"/>
-                <CheckBox Name="chkUseAutoDiscover" FlowDirection="LeftToRight" IsChecked="{Binding Path=IsAutodiscoverEnabled, Mode=TwoWay}" >
+                <CheckBox Name="chkUseAutoDiscover" FlowDirection="LeftToRight" IsChecked="{Binding Path=IsAutodiscoverEnabled, Mode=TwoWay}" HorizontalAlignment="Left" Width="293" Checked="chkUseAutoDiscover_Checked" Unchecked="chkUseAutoDiscover_Unchecked" Margin="10,0,0,0" >
                     <TextBlock FlowDirection="LeftToRight" Text="Use Autodiscover" />
                 </CheckBox>
 

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/GeneralSettingsForm.xaml.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/GeneralSettingsForm.xaml.cs
@@ -36,5 +36,16 @@ namespace SMLetsExchangeConnectorSettingsUI
         {
 
         }
+
+        //toggle AutoDiscover URL textbox availability
+        private void chkUseAutoDiscover_Checked(object sender, RoutedEventArgs e)
+        {
+            this.txtAutodiscoverURL.IsEnabled = false;
+        }
+
+        private void chkUseAutoDiscover_Unchecked(object sender, RoutedEventArgs e)
+        {
+            this.txtAutodiscoverURL.IsEnabled = true;
+        }
     }
 }


### PR DESCRIPTION
Introducing logic that controls the Autodiscover URL Textbox enabled property based on the if the Autodiscover option has been checked or not.

While validation hasn't been introduced here, this results in a noticeable/visible change when toggling the checkbox that should help stand out during configuration.