### PR TITLE
problem saving logging type

### DIFF
--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/Logging.xaml.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/Logging.xaml.cs
@@ -51,5 +51,12 @@ namespace SMLetsExchangeConnectorSettingsUI
         {
 
         }
+        
+        //when the form is saved, these values/objects will be passed back over to AdminSettingsWizardData's "AcceptChanges" event
+        public override void SaveState(SavePageEventArgs e)
+        {
+            settings.LoggingLevel = cbLoggingLevel.Text;
+            settings.LoggingType = cbLoggingType.Text;
+        }
     }
 }


### PR DESCRIPTION
Discovered an issue with the initial save of the form when using logging with workflows i.e. Windows Event Log.

Workaround is to choose SMA/Azure Automation, save it, re-open, and then choose Workflows.