### PR TITLE
Exchange Impersonation

### DIFF
--- a/ManagementPack/2016/SMLets.Exchange.Connector/Settings.mpx
+++ b/ManagementPack/2016/SMLets.Exchange.Connector/Settings.mpx
@@ -34,6 +34,11 @@
               Type="bool"
               Key="false"
               Required="false" />
+              
+          <Property ID="UseImpersonation"
+              Type="bool"
+              Key="false"
+              Required="false" />
 
           <Property ID="ExchangeAutodiscoverURL"
               Type="string"

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -24,6 +24,7 @@ namespace SMLetsExchangeConnectorSettingsUI
         private String strscsmMGMTServer = String.Empty;
         private String strWorkflowEmailAddress = String.Empty;
         private Boolean boolEnableAutodiscover = false;
+        private Boolean boolEnableImpersonation = false;
         private String strAutodiscoverURL = String.Empty;
         private Boolean boolEnableExchangeOnline = false;
         private String strAzureTenantID = String.Empty;
@@ -286,6 +287,21 @@ namespace SMLetsExchangeConnectorSettingsUI
                 if (this.boolEnableAutodiscover != value)
                 {
                     this.boolEnableAutodiscover = value;
+                }
+            }
+        }
+        
+        public Boolean IsImpersonationEnabled
+        {
+            get
+            {
+                return this.boolEnableImpersonation;
+            }
+            set
+            {
+                if (this.boolEnableImpersonation != value)
+                {
+                    this.boolEnableImpersonation = value;
                 }
             }
         }
@@ -2522,6 +2538,10 @@ namespace SMLetsExchangeConnectorSettingsUI
             //Autodiscover
             try { this.IsAutodiscoverEnabled = Boolean.Parse(emoAdminSetting[smletsExchangeConnectorSettingsClass, "UseAutoDiscover"].ToString()); }
             catch { this.IsAutodiscoverEnabled = false; }
+            
+            //Impersonation
+            try { this.IsImpersonationEnabled = Boolean.Parse(emoAdminSetting[smletsExchangeConnectorSettingsClass, "UseImpersonation"].ToString()); }
+            catch { this.IsImpersonationEnabled = false; }
 
             //DLL Paths - EWS, Mimekit, PII regex, HTML Suyggestions, Custom Events
             this.EWSFilePath = emoAdminSetting[smletsExchangeConnectorSettingsClass, "FilePathEWSDLL"].ToString();
@@ -3242,6 +3262,7 @@ namespace SMLetsExchangeConnectorSettingsUI
             //General Settings
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMmgmtServer"].Value = this.SCSMmanagementServer;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "WorkflowEmailAddress"].Value = this.WorkflowEmailAddress;
+            emoAdminSetting[smletsExchangeConnectorSettingsClass, "UseImpersonation"].Value = this.IsImpersonationEnabled;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "UseAutoDiscover"].Value = this.IsAutodiscoverEnabled;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "ExchangeAutodiscoverURL"].Value = this.ExchangeAutodiscoverURL;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "UseExchangeOnline"].Value = this.IsExchangeOnline;

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/GeneralSettingsForm.xaml
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/GeneralSettingsForm.xaml
@@ -27,7 +27,11 @@
 
                 <TextBlock Margin="10,0,0,0" x:Name="lblRunAsAccountEWS" TextWrapping="Wrap" Text="Run As Account to connect to Exchange" />
                 <ComboBox Margin="10,0" ItemsSource="{Binding Path=SecureRunAsAccounts}" DisplayMemberPath="DisplayName" SelectedItem="{Binding RunAsAccountEWS, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
-                
+
+                <CheckBox Name="chkUseImpersonation" FlowDirection="LeftToRight" IsChecked="{Binding Path=IsImpersonationEnabled, Mode=TwoWay}" HorizontalAlignment="Left" Width="293" Margin="10,10,0,0" >
+                    <TextBlock FlowDirection="LeftToRight" Text="Use Impersonation" />
+                </CheckBox>
+
                 <CheckBox Name="chkUseAutoDiscover" FlowDirection="LeftToRight" IsChecked="{Binding Path=IsAutodiscoverEnabled, Mode=TwoWay}" HorizontalAlignment="Left" Width="293" Checked="chkUseAutoDiscover_Checked" Unchecked="chkUseAutoDiscover_Unchecked" Margin="10,10,0,0" >
                     <TextBlock FlowDirection="LeftToRight" Text="Use Autodiscover" />
                 </CheckBox>

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3846,6 +3846,11 @@ if ($scsmLFXConfigMP.GetRules() | Where-Object {($_.Name -eq "SMLets.Exchange.Co
             $exchangeService.Url = [System.Uri]$ExchangeEndpoint
         }
     }
+    #impersonation is being used with the workflow
+    if ($smexcoSettingsMP.UseImpersonation)
+    {
+        $exchangeService.ImpersonatedUserId = [Microsoft.Exchange.WebServices.Data.ImpersonatedUserId]::new([Microsoft.Exchange.WebServices.Data.ConnectingIdType]::SmtpAddress, $workflowEmailAddress)
+    }
 }
 else
 {


### PR DESCRIPTION
By introducing Impersonation support, proper Exchange permissions (that exist outside the scope of the connector) must be given to the Run as Account chosen to authenticate to Exchange to successfully work.

- [x] Add new property to SMLets Exchange Connector Admin Settings class
- [x] Add new checkbox control to the General tab in the Settings UI
- [x] Bind the checkbox control to the property
- [x] Introduce logic to PowerShell to support Impersonation
- [x] Test impersonation by giving the Run as Account as defined in the Settings UI Exchange Impersonation rights, authenticating to Exchange, then reading Service Manager inbox