### PR TITLE
Regional decimal formatting

### DIFF
--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -3295,6 +3295,12 @@ namespace SMLetsExchangeConnectorSettingsUI
             //Get the SMLets Exchange Connector Settings object using the object GUID 
             EnterpriseManagementObject emoAdminSetting = emg.EntityObjects.GetObject<EnterpriseManagementObject>(this.EnterpriseManagementObjectID, ObjectQueryOptions.Default);
 
+            //Declare current region and allowed number formats
+            NumberStyles numberRegionStyle;
+            CultureInfo currentCulture;
+            numberRegionStyle = NumberStyles.AllowDecimalPoint;
+            currentCulture = CultureInfo.CurrentCulture;
+
             //General Settings
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMmgmtServer"].Value = this.SCSMmanagementServer;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "WorkflowEmailAddress"].Value = this.WorkflowEmailAddress;

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -3545,8 +3545,15 @@ namespace SMLetsExchangeConnectorSettingsUI
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "ACSTextAnalyticsRegion"].Value = this.ACSRegion;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "ACSTextAnalyticsAPIKey"].Value = this.AzureCognitiveServicesAPIKey;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "ACSPriorityScoringBoundaries"].Value = this.AzureCognitiveServicesBoundaries.ToString();
-            try { decimal.Parse(this.MinimumPercentToCreateServiceRequest); emoAdminSetting[smletsExchangeConnectorSettingsClass, "MinACSSentimentToCreateSR"].Value = this.MinimumPercentToCreateServiceRequest; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "MinACSSentimentToCreateSR"].Value = 95; }
+            decimal cultureParsedMinACSSentimentToCreateSR;
+            if (Decimal.TryParse(this.MinimumPercentToCreateServiceRequest, numberRegionStyle, currentCulture, out cultureParsedMinACSSentimentToCreateSR))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "MinACSSentimentToCreateSR"].Value = cultureParsedMinACSSentimentToCreateSR.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "MinACSSentimentToCreateSR"].Value = 95.0;
+            }
             try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "ACSSentimentScoreIncidentClassExtensionGUID"].Value = this.ACSIncidentSentimentDecExtension.Id; }
             catch { }
             try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "ACSSentimentScoreServiceRequestClassExtensionGUID"].Value = this.ACSServiceRequestSentimentDecExtension.Id; }

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -3365,7 +3365,15 @@ namespace SMLetsExchangeConnectorSettingsUI
             catch { }
 
             //File Attachments
-            emoAdminSetting[smletsExchangeConnectorSettingsClass, "MinimumFileAttachmentSize"].Value = this.MinFileAttachmentSize;
+            decimal cultureParsedMinFileSize;
+            if (Decimal.TryParse(this.MinFileAttachmentSize, numberRegionStyle, currentCulture, out cultureParsedMinFileSize))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "MinimumFileAttachmentSize"].Value = cultureParsedMinFileSize.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "MinimumFileAttachmentSize"].Value = 5.0;
+            }
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "EnforceFileAttachmentSettings"].Value = this.IsMaxFileSizeAttachmentsEnabled;
 
             //Default Templates

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -3517,12 +3517,33 @@ namespace SMLetsExchangeConnectorSettingsUI
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementKeywordLow"].Value = this.LowPriorityAnnouncementKeyword;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementKeywordMedium"].Value = this.MediumPriorityAnnouncementKeyword;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementKeywordHigh"].Value = this.HighPriorityAnnouncementKeyword;
-            try { decimal.Parse(this.LowPriorityExpiresInHours); emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityLowExpirationInHours"].Value = this.LowPriorityExpiresInHours; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityLowExpirationInHours"].Value = 0; }
-            try { decimal.Parse(this.MediumPriorityExpiresInHours); emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityNormalExpirationInHours"].Value = this.MediumPriorityExpiresInHours; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityNormalExpirationInHours"].Value = 0; }
-            try { decimal.Parse(this.HighPriorityExpiresInHours); emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityCriticalExpirationInHours"].Value = this.HighPriorityExpiresInHours; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityCriticalExpirationInHours"].Value = 0; }
+                        decimal cultureParsedLowPriorityAnnounce;
+            if (Decimal.TryParse(this.LowPriorityExpiresInHours, numberRegionStyle, currentCulture, out cultureParsedLowPriorityAnnounce))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityLowExpirationInHours"].Value = cultureParsedLowPriorityAnnounce.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityLowExpirationInHours"].Value = 0;
+            }
+            decimal cultureParsedMedPriorityAnnounce;
+            if (Decimal.TryParse(this.MediumPriorityExpiresInHours, numberRegionStyle, currentCulture, out cultureParsedMedPriorityAnnounce))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityNormalExpirationInHours"].Value = cultureParsedMedPriorityAnnounce.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityNormalExpirationInHours"].Value = 0;
+            }
+            decimal cultureParsedHighPriorityAnnounce;
+            if (Decimal.TryParse(this.HighPriorityExpiresInHours, numberRegionStyle, currentCulture, out cultureParsedHighPriorityAnnounce))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityCriticalExpirationInHours"].Value = cultureParsedHighPriorityAnnounce.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AnnouncementPriorityCriticalExpirationInHours"].Value = 0;
+            }
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementUsers"].Value = this.SCSMApprovedAnnouncers;
             //if the Announcement group is set, don't null it
             try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementGroupGUID"].Value = this.SCSMApprovedAnnouncementGroup["Id"]; }

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -3592,14 +3592,42 @@ namespace SMLetsExchangeConnectorSettingsUI
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "EnableAML"].Value = this.IsAzureMachineLearningEnabled;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLAPIKey"].Value = this.AzureMachineLearningAPIKey;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLurl"].Value = this.AzureMachineLearningURL;
-            try { decimal.Parse(this.AzureMachineLearningWIConfidence); emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemType"].Value = this.AzureMachineLearningWIConfidence; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemType"].Value = 95; }
-            try { decimal.Parse(this.AzureMachineLearningClassificationConfidence); emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemClassification"].Value = this.AzureMachineLearningClassificationConfidence; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemClassification"].Value = 95; }
-            try { decimal.Parse(this.AzureMachineLearningSupportGroupConfidence); emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemSupportGroup"].Value = this.AzureMachineLearningSupportGroupConfidence; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemSupportGroup"].Value = 95; }
-            try { decimal.Parse(this.AzureMachineLearningAffectedConfigItemConfidence); emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceImpactedConfigItem"].Value = this.AzureMachineLearningAffectedConfigItemConfidence; }
-            catch { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceImpactedConfigItem"].Value = 95; }
+            decimal cultureParsedAMLWIConfidence;
+            if (Decimal.TryParse(this.AzureMachineLearningWIConfidence, numberRegionStyle, currentCulture, out cultureParsedAMLWIConfidence))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemType"].Value = cultureParsedAMLWIConfidence.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemType"].Value = 95;
+            }
+            decimal cultureParsedAMLClassificationConfidence;
+            if (Decimal.TryParse(this.AzureMachineLearningClassificationConfidence, numberRegionStyle, currentCulture, out cultureParsedAMLClassificationConfidence))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemClassification"].Value = cultureParsedAMLClassificationConfidence.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemClassification"].Value = 95;
+            }
+            decimal cultureParsedAMLSupportGroupConfidence;
+            if (Decimal.TryParse(this.AzureMachineLearningSupportGroupConfidence, numberRegionStyle, currentCulture, out cultureParsedAMLSupportGroupConfidence))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemSupportGroup"].Value = cultureParsedAMLSupportGroupConfidence.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceWorkItemSupportGroup"].Value = 95;
+            }
+            decimal cultureParsedAMLConfigItemConfidence;
+            if (Decimal.TryParse(this.AzureMachineLearningAffectedConfigItemConfidence, numberRegionStyle, currentCulture, out cultureParsedAMLConfigItemConfidence))
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceImpactedConfigItem"].Value = cultureParsedAMLConfigItemConfidence.ToString(CultureInfo.InvariantCulture.NumberFormat);
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLMinConfidenceImpactedConfigItem"].Value = 95;
+            }
 
             try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "AMLIncidentConfidenceClassExtensionGUID"].Value = this.AMLIncidentConfidenceDecExtension.Id; }
             catch { }

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -11,6 +11,7 @@ using Microsoft.EnterpriseManagement.Configuration;
 using Microsoft.Win32;
 using Microsoft.EnterpriseManagement.ConnectorFramework;
 using System.Xml;
+using System.Globalization;
 
 namespace SMLetsExchangeConnectorSettingsUI
 {

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/FileAttachmentForm.xaml
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/FileAttachmentForm.xaml
@@ -15,7 +15,7 @@
         <!-- configuration -->
         <StackPanel Name="stackPanel" Orientation="Vertical" Margin="10,82,155,10">
             <TextBlock Name="txtblkMinFileSizeInKB" Text="Minimum File Size in KB before File Attached (e.g. 21.45)" Margin="10,5,0,0" />
-            <TextBox x:Name="txtMinFileSizeInKB" Height="23" TextWrapping="Wrap" Margin="10,0,176.5,0" Text="{Binding MinFileAttachmentSize, Mode=TwoWay}" Custom:Validation.RegexPattern="^^[.][0-9]+$|^[0-9]*[.]{0,1}[0-9]*$" />
+            <TextBox x:Name="txtMinFileSizeInKB" Height="23" TextWrapping="Wrap" Margin="10,0,176.5,0" Text="{Binding MinFileAttachmentSize, Mode=TwoWay}" />
             <CheckBox Name="chkMaxFileSize" FlowDirection="LeftToRight" IsChecked="{Binding Path=IsMaxFileSizeAttachmentsEnabled, Mode=TwoWay}" Margin="10,5,0,0" >
                 <TextBlock FlowDirection="LeftToRight" Text="Enforce Maximum Attachment Size per individually defined Work Item Settings" TextWrapping="Wrap" />
             </CheckBox>


### PR DESCRIPTION
Given the management pack could be deployed in any number of regions, it's possible that the region in question may not use a period as a decimal delimiter. As a result, text boxes in the UI that enforce decimal delimiters with a period don't pass validation and thus the Settings UI can't be saved.

- File Attachments
    - [x] Minimum File Attachment Size

- Announcements
    - [x] Announcement Low Priority Expiring in Hours
    - [x] Announcement Medium Priority Expiring in Hours
    - [x] Announcement High Priority Expiring in Hours

- AI, Azure Cognitive Services
    - [x] Minimum Sentiment to Create SR

- AI, Azure Machine Learning
    - [x] Minimum Confidence to decide Work Item Type
    - [x] Minimum Confidence to decide Work Item Classification
    - [x] Minimum Confidence to decide Work Item Support Group
    - [x] Minimum Confidence to decide Impacted Configuration Item(s)