### PR TITLE
Repository MimeKit dependency

### DIFF
--- a/ManagementPack/2016/dependencies/External.csproj
+++ b/ManagementPack/2016/dependencies/External.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net45</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Mimekit" Version="2.9.2" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
The introduction of this file will show the SMLets Exchange Connector repo as dependent on the [MimeKit](https://github.com/jstedfast/MimeKit) project.