### PR TITLE
Repository Exchange Web Services dependency

### DIFF
--- a/ManagementPack/2016/dependencies/External.csproj
+++ b/ManagementPack/2016/dependencies/External.csproj
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Exchange.WebServices" Version="2.2.0" />
     <PackageReference Include="Mimekit" Version="2.9.2" />
   </ItemGroup>
 


### PR DESCRIPTION
The introduction of this line to the External.csproj will show the SMLets Exchange Connector repo as dependent on the [Exchange Web Services](https://github.com/OfficeDev/ews-managed-api) repo.