### PR TITLE
Class and MP naming precision

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2398,7 +2398,7 @@ function Get-TierMembership ($UserSamAccountName, $TierId) {
     $isMember = $false
 
     #define classes
-    $mapCls = Get-ScsmClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping"
+    $mapCls = Get-ScsmClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping$"
 
     #pull the group based on support tier mapping
     $mapping = $mapCls | Get-ScsmObject @scsmMGMTParams | ? { $_.SupportGroupId.Guid -eq $TierId.Guid }
@@ -2431,7 +2431,7 @@ function Get-TierMembers ($TierEnumId)
     if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-TierMembers" -EventID 0 -Severity "Information" -LogMessage "Get AD Group Associated with enum: $TierEnumId"}
     
     #define classes
-    $mapCls = Get-ScsmClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping"
+    $mapCls = Get-ScsmClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping$"
 
     #pull the group based on support tier mapping
     $mapping = $mapCls | Get-ScsmObject @scsmMGMTParams | ? { $_.SupportGroupId.Guid -eq $TierEnumId }
@@ -3143,7 +3143,7 @@ function Get-TemplatesByMailbox ($message)
 function Get-SCSMWorkItemSettings ($WorkItemClass) {   
     switch ($WorkItemClass) {
         "System.WorkItem.Incident" {
-            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.WorkItem.Incident.GeneralSetting"
+            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.WorkItem.Incident.GeneralSetting$"
             $settings = $settingCls | Get-ScsmObject @scsmMGMTParams
             $maxAttach = $settings.MaxAttachments
             $maxSize = $settings.MaxAttachmentSize
@@ -3152,7 +3152,7 @@ function Get-SCSMWorkItemSettings ($WorkItemClass) {
             foreach ($char in $prefix.tochararray()) {$prefixRegex += "[" + $char + "]"}
         }
         "System.WorkItem.ServiceRequest" {
-            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ServiceRequestSettings"
+            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ServiceRequestSettings$"
             $settings = $settingCls | Get-ScsmObject @scsmMGMTParams
             $maxAttach = $settings.MaxFileAttachmentsCount
             $maxSize = $settings.MaxFileAttachmentSizeinKB
@@ -3161,7 +3161,7 @@ function Get-SCSMWorkItemSettings ($WorkItemClass) {
             foreach ($char in $prefix.tochararray()) {$prefixRegex += "[" + $char + "]"}
         }
         "System.WorkItem.ChangeRequest" {
-            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ChangeSettings"
+            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ChangeSettings$"
             $settings = $settingCls | Get-ScsmObject @scsmMGMTParams
             $maxAttach = $settings.MaxFileAttachmentsCount
             $maxSize = $settings.MaxFileAttachmentSizeinKB
@@ -3170,7 +3170,7 @@ function Get-SCSMWorkItemSettings ($WorkItemClass) {
             foreach ($char in $prefix.tochararray()) {$prefixRegex += "[" + $char + "]"}
         }
         "System.WorkItem.Problem" {
-            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ProblemSettings"
+            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ProblemSettings$"
             $settings = $settingCls | Get-ScsmObject @scsmMGMTParams
             $maxAttach = $settings.MaxFileAttachmentsCount
             $maxSize = $settings.MaxFileAttachmentSizeinKB
@@ -3179,7 +3179,7 @@ function Get-SCSMWorkItemSettings ($WorkItemClass) {
             foreach ($char in $prefix.tochararray()) {$prefixRegex += "[" + $char + "]"}
         }
         "System.WorkItem.Release" {
-            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ReleaseSettings"
+            $settingCls = Get-ScsmClass @scsmMGMTParams -Name "System.GlobalSetting.ReleaseSettings$"
             $settings = $settingCls | Get-ScsmObject @scsmMGMTParams
             $maxAttach = $settings.MaxFileAttachmentsCount
             $maxSize = $settings.MaxFileAttachmentSizeinKB
@@ -3888,7 +3888,7 @@ function Apply-SCSMTemplate
  
     #Get alias from system.workitem.library managementpack to set id property
     $templateMP = $Template.GetManagementPack() 
-    $alias = $templateMP.References.GetAlias((Get-SCSMManagementPack system.workitem.library @scsmMGMTParams))
+    $alias = $templateMP.References.GetAlias((Get-SCSMManagementPack "System.WorkItem.Library$" @scsmMGMTParams))
     
     #Update Activities in template
     foreach ($TemplateObject in $Template.ObjectCollection)


### PR DESCRIPTION
While the chances of having similar naming conventions to these classes/management packs are slim given the context, they are never the less present. With the introduction of the "$" the possibility of returning multiple results is removed.