### PR TITLE
Error Handling for Dynamic Analyst Assignment

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1154,7 +1154,14 @@ function New-WorkItem ($message, $wiType, $returnWIBool)
                     elseif ($DynamicWorkItemAssignment)
                     {
                         $templateSupportGroupID = $IRTemplate | select-object -expandproperty propertycollection | where-object{($_.path -like "*TierQueue*")} | select-object -ExpandProperty mixedvalue
-                        Set-AssignedToPerSupportGroup -SupportGroupID $templateSupportGroupID -WorkItem $newWorkItem
+                        if ($templateSupportGroupID)
+                        {
+                            Set-AssignedToPerSupportGroup -SupportGroupID $templateSupportGroupID -WorkItem $newWorkItem
+                        }
+                        else
+                        {
+                            New-SMEXCOEvent -Source "Set-AssignedToPerSupportGroup" -EventID 3 -Severity "Warning" -LogMessage "The Assigned To User could not be set on $($newWorkItem.Name). Using Template: $($IRTemplate.DisplayName). This Template either does not have a Support Group defined that corresponds to a mapped Cireson Portal Group Mapping OR the Template being used/was copied from an OOB SCSM Template"
+                        }
                     }
                     
                     #### Determine auto-response logic for Knowledge Base and/or Request Offering Search ####
@@ -1302,7 +1309,14 @@ function New-WorkItem ($message, $wiType, $returnWIBool)
                     elseif ($DynamicWorkItemAssignment)
                     {
                         $templateSupportGroupID = $SRTemplate | select-object -expandproperty propertycollection | where-object{($_.path -like "*SupportGroup*")} | select-object -ExpandProperty mixedvalue
-                        Set-AssignedToPerSupportGroup -SupportGroupID $templateSupportGroupID -WorkItem $newWorkItem
+                        if ($templateSupportGroupID)
+                        {
+                            Set-AssignedToPerSupportGroup -SupportGroupID $templateSupportGroupID -WorkItem $newWorkItem
+                        }
+                        else
+                        {
+                            New-SMEXCOEvent -Source "Set-AssignedToPerSupportGroup" -EventID 3 -Severity "Warning" -LogMessage "The Assigned To User could not be set on $($newWorkItem.Name). Using Template: $($SRTemplate.DisplayName). This Template either does not have a Support Group defined that corresponds to a mapped Cireson Portal Group Mapping OR the Template being used/was copied from an OOB SCSM Template"
+                        }
                     }
                     
                     #### Determine auto-response logic for Knowledge Base and/or Request Offering Search ####


### PR DESCRIPTION
Adding error handling for when Dynamic Analyst Assignment is used when the TierQueue/Support Group can't be determined on the Template. This addresses both missing enums on the template or an OOB template that is used/duplicated.

- [x] Update [Logging Wiki](https://github.com/AdhocAdam/smletsexchangeconnector/wiki/Logging)