### PR TITLE
Email and File Attachment logging

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2174,7 +2174,7 @@ function Attach-EmailToWorkItem ($message, $workItemID)
         }
         else
         {
-                if ($loggingLevel -ge 2){New-SMEXCOEvent -Source "Attach-EmailToWorkItem" -EventID 0 -Severity "Warning" -LogMessage "Email from $($message.From) on $workItemID was not attached. Current Attachment Count: $existingAttachmentsCount/$($workItemSettings["MaxAttachments"]). File Size/Allowed Size: $($MemoryStream.Length/1024)/$($workItemSettings["MaxAttachmentSize"])"}
+            if ($loggingLevel -ge 2){New-SMEXCOEvent -Source "Attach-EmailToWorkItem" -EventID 0 -Severity "Warning" -LogMessage "Email from $($message.From) on $workItemID was not attached. Current Attachment Count: $existingAttachmentsCount/$($workItemSettings["MaxAttachments"]). File Size/Allowed Size: $($MemoryStream.Length/1024)/$($workItemSettings["MaxAttachmentSize"])"}
         }
     }
     catch

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2204,6 +2204,8 @@ function Attach-FileToWorkItem ($message, $workItemId)
     
     foreach ($attachment in $message.Attachments)
     {
+        try
+        {
         #determine if a File Attachment
         if ($attachment.GetType().Name -eq "FileAttachment")
         {
@@ -2369,6 +2371,11 @@ function Attach-FileToWorkItem ($message, $workItemId)
                 New-SCSMRelationshipObject -Source $NewFile -Relationship $fileAddedByUserRelClass -Target $attachedByUser @scsmMGMTParams -Bulk
                 $existingAttachmentsCount += 1
             }
+        }
+        }
+        catch
+        {
+            #file could not be added
         }
     }
     # Custom Event Handler

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2376,6 +2376,7 @@ function Attach-FileToWorkItem ($message, $workItemId)
         catch
         {
             #file could not be added
+            if ($loggingLevel -ge 2){New-SMEXCOEvent -Source "Attach-FileToWorkItem" -EventID 0 -Severity "Warning" -LogMessage "A File Attachment from $($message.From) could not be added to $workItemId. $($_.Exception)"}
         }
     }
     # Custom Event Handler

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2166,17 +2166,17 @@ function Attach-EmailToWorkItem ($message, $workItemID)
             $attachedByUser = Get-SCSMUserByEmailAddress -EmailAddress "$($message.from)"
             if ($attachedByUser)
             {
-                    New-SCSMRelationshipObject -Source $emailAttachment -Relationship $fileAddedByUserRelClass -Target $attachedByUser @scsmMGMTParams -Bulk
+                New-SCSMRelationshipObject -Source $emailAttachment -Relationship $fileAddedByUserRelClass -Target $attachedByUser @scsmMGMTParams -Bulk
             }
                 
             # Custom Event Handler
-                if ($ceScripts) { Invoke-AfterAttachEmail }
+            if ($ceScripts) { Invoke-AfterAttachEmail }
         }
         else
         {
                 if ($loggingLevel -ge 2){New-SMEXCOEvent -Source "Attach-EmailToWorkItem" -EventID 0 -Severity "Warning" -LogMessage "Email from $($message.From) on $workItemID was not attached. Current Attachment Count: $existingAttachmentsCount/$($workItemSettings["MaxAttachments"]). File Size/Allowed Size: $($MemoryStream.Length/1024)/$($workItemSettings["MaxAttachmentSize"])"}
         }
-        }
+    }
     catch
     {
         if ($loggingLevel -ge 2){New-SMEXCOEvent -Source "Attach-EmailToWorkItem" -EventID 1 -Severity "Warning" -LogMessage "Email from $($message.From) on $workItemID could not be attached. $($_.Exception)"}


### PR DESCRIPTION
- [x] If an email can't be added to the Work Item because it exceeds the allowed file size or attachment count, log an event explaining this
- [x] If an email can't be added because the mime content fails to parse, log an event explaining some context about the message along with the exception.
- [x] If a file can't be added, log an event
- [x] Update [Logging Wiki](https://github.com/AdhocAdam/smletsexchangeconnector/wiki/Logging)