### PR TITLE
Support Group functions (merge conflict from #292)

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2397,63 +2397,80 @@ function Get-SCSMUserByEmailAddress ($EmailAddress)
 function Get-TierMembership ($UserSamAccountName, $TierId) {
     $isMember = $false
 
-    #define classes
-    $mapCls = Get-ScsmClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping$"
+    try
+    {
+        #define classes
+        $mapCls = Get-SCSMClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping$"
 
-    #pull the group based on support tier mapping
-    $mapping = $mapCls | Get-ScsmObject @scsmMGMTParams | ? { $_.SupportGroupId.Guid -eq $TierId.Guid }
-    $groupId = $mapping.AdGroupId
+        #pull the group based on support tier mapping
+        $mapping = $mapCls | Get-SCSMObject @scsmMGMTParams | ? { $_.SupportGroupId.Guid -eq $TierId.Guid }
+        $groupId = $mapping.AdGroupId
 
-    #get the AD group object name
-    $grpInScsm = (Get-ScsmObject @scsmMGMTParams -Id $groupId)
-    $grpSamAccountName = $grpInScsm.UserName
-    
-    #determine which domain to query, in case of multiple domains and trusts
-    $AdRoot = (Get-AdDomain @adParams -Identity $grpInScsm.Domain).DNSRoot
+        #get the AD group object name
+        $grpInScsm = (Get-SCSMObject @scsmMGMTParams -Id $groupId)
+        $grpSamAccountName = $grpInScsm.UserName
+        
+        #determine which domain to query, in case of multiple domains and trusts
+        $AdRoot = (Get-ADDomain @adParams -Identity $grpInScsm.Domain).DNSRoot
 
-    if ($grpSamAccountName) {
-        # Get the group membership
-        [array]$members = Get-ADGroupMember @adParams -Server $AdRoot -Identity $grpSamAccountName -Recursive
+        if ($grpSamAccountName) {
+            # Get the group membership
+            [array]$members = Get-ADGroupMember @adParams -Server $AdRoot -Identity $grpSamAccountName -Recursive
 
-        # loop through the members of the AD group that underpins this support group, and look for the user
-        $members | % {
-            if ($_.objectClass -eq "user" -and $_.Name -match $UserSamAccountName) {
-                $isMember = $true
+            # loop through the members of the AD group that underpins this support group, and look for the user
+            $members | % {
+                if ($_.objectClass -eq "user" -and $_.Name -match $UserSamAccountName) {
+                    $isMember = $true
+                }
             }
         }
     }
+    catch
+    {
+        New-SMEXCOEvent -Source "Get-TierMembership" -Severity "Warning" -EventID 0 -LogMessage $_.Exception
+    }
+
     return $isMember
 }
 
 function Get-TierMembers ($TierEnumId)
 {
-    #logging
-    if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-TierMembers" -EventID 0 -Severity "Information" -LogMessage "Get AD Group Associated with enum: $TierEnumId"}
+    $supportTierMembers = $null
     
-    #define classes
-    $mapCls = Get-ScsmClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping$"
-
-    #pull the group based on support tier mapping
-    $mapping = $mapCls | Get-ScsmObject @scsmMGMTParams | ? { $_.SupportGroupId.Guid -eq $TierEnumId }
-    $groupId = $mapping.AdGroupId
-    if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-TierMembers" -EventID 1 -Severity "Information" -LogMessage "Get SCSM object/Group for: $groupId"}
-
-    #get the AD group object name
-    $grpInScsm = (Get-ScsmObject @scsmMGMTParams -Id $groupId)
-    $grpSamAccountName = $grpInScsm.UserName
-    if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-TierMembers" -EventID 2 -Severity "Information" -LogMessage "AD Group Name: $grpSamAccountName"}
-    
-    #determine which domain to query, in case of multiple domains and trusts
-    $AdRoot = (Get-AdDomain @adParams -Identity $grpInScsm.Domain).DNSRoot
-
-    if ($grpSamAccountName)
+    try
     {
-        # Get the group membership
-        [array]$supportTierMembers = Get-ADGroupMember @adParams -Server $AdRoot -Identity $grpSamAccountName -Recursive | foreach-object {Get-SCSMObject -Class $domainUserClass -filter "Username -eq '$($_.samaccountname)'"}
-        if ($loggingLevel -ge 4) {
-            $supportTierMembersLogString = $supportTierMembers.Name -join ","
-            New-SMEXCOEvent -Source "Get-TierMembers" -EventID 3 -Severity "Information" -LogMessage "AD Group Members: $supportTierMembersLogString"
-        }
+        #logging
+        if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-TierMembers" -EventID 0 -Severity "Information" -LogMessage "Get AD Group Associated with enum: $TierEnumId"}
+        
+        #define classes
+        $mapCls = Get-ScsmClass @scsmMGMTParams -Name "Cireson.SupportGroupMapping$"
+
+        #pull the group based on support tier mapping
+        $mapping = $mapCls | Get-ScsmObject @scsmMGMTParams | ? { $_.SupportGroupId.Guid -eq $TierEnumId }
+        $groupId = $mapping.AdGroupId
+        if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-TierMembers" -EventID 1 -Severity "Information" -LogMessage "Get SCSM object/Group for: $groupId"}
+
+        #get the AD group object name
+        $grpInScsm = (Get-ScsmObject @scsmMGMTParams -Id $groupId)
+        $grpSamAccountName = $grpInScsm.UserName
+        if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-TierMembers" -EventID 2 -Severity "Information" -LogMessage "AD Group Name: $grpSamAccountName"}
+        
+        #determine which domain to query, in case of multiple domains and trusts
+        $AdRoot = (Get-AdDomain @adParams -Identity $grpInScsm.Domain).DNSRoot
+
+        if ($grpSamAccountName)
+        {
+            # Get the group membership
+            [array]$supportTierMembers = Get-ADGroupMember @adParams -Server $AdRoot -Identity $grpSamAccountName -Recursive | foreach-object {Get-SCSMObject -Class $domainUserClass -filter "Username -eq '$($_.samaccountname)'"}
+            if ($loggingLevel -ge 4) {
+                $supportTierMembersLogString = $supportTierMembers.Name -join ","
+                New-SMEXCOEvent -Source "Get-TierMembers" -EventID 3 -Severity "Information" -LogMessage "AD Group Members: $supportTierMembersLogString"
+            }
+        }    
+    }
+    catch
+    {
+        New-SMEXCOEvent -Source "Get-TierMembers" -EventID 4 -Severity "Warning" -LogMessage $_.Exception
     }
     return $supportTierMembers
 }


### PR DESCRIPTION
Re-doing the branch and associated changes. If the support group mapping cannot be obtained for any reason i.e. MP doesn't exist, the mapping doesn't exist, or AD can't be contacted then the function returns a $false result and logs an event. If the members of a Support Group can't be retrieved, return a null result and log an event. updating formatting/style of powershell

- [x] eliminate possibility of more than 1 class being returned
- [x] error handling in the event of null results or AD failure
- [x] Update [Logging Wiki](https://github.com/AdhocAdam/smletsexchangeconnector/wiki/Logging)