### PR TITLE
File Attachment Support for Activities

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1509,9 +1509,28 @@ function Update-WorkItem ($message, $wiType, $workItemID)
     #add any attachments
     if ($message.Attachments)
     {
-        Attach-FileToWorkItem $message $workItemID
+        if ($loggingLevel -ge 4)
+        {
+            $logMessage = "Attaching File
+            From: $($message.From)
+            Title: $($message.Subject)"
+            New-SMEXCOEvent -Source "Update-WorkItem" -EventId 0 -LogMessage $logMessage -Severity "Information"
+        }
+        switch ($wiType)
+        {
+            "ma" {
+                    $workItem = get-scsmobject -class $maClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
+                    $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Guid
+                    Attach-FileToWorkItem $message $parentWorkItem
+                 }
+            "ra" {
+                    $workItem = get-scsmobject -class $raClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
+                    $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Guid
+                    Attach-FileToWorkItem $message $parentWorkItem
+                 }
+            default { Attach-FileToWorkItem $message $workItemID }
+       }
     }
-
     #show the user who will perform the update and the [action] they are taking. If there is no [action] it's just a comment
     if ($loggingLevel -ge 4)
     {

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1520,12 +1520,12 @@ function Update-WorkItem ($message, $wiType, $workItemID)
         {
             "ma" {
                     $workItem = get-scsmobject -class $maClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
-                    $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Guid
+                    $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
                     Attach-FileToWorkItem $message $parentWorkItem
                  }
             "ra" {
                     $workItem = get-scsmobject -class $raClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
-                    $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Guid
+                    $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
                     Attach-FileToWorkItem $message $parentWorkItem
                  }
             default { Attach-FileToWorkItem $message $workItemID }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1509,13 +1509,6 @@ function Update-WorkItem ($message, $wiType, $workItemID)
     #add any attachments
     if ($message.Attachments)
     {
-        if ($loggingLevel -ge 4)
-        {
-            $logMessage = "Attaching File
-            From: $($message.From)
-            Title: $($message.Subject)"
-            New-SMEXCOEvent -Source "Update-WorkItem" -EventId 0 -LogMessage $logMessage -Severity "Information"
-        }
         switch ($wiType)
         {
             "ma" {
@@ -2267,6 +2260,15 @@ function Attach-FileToWorkItem ($message, $workItemId)
     
     foreach ($attachment in $message.Attachments)
     {
+        #file attachment logging
+        if ($loggingLevel -ge 4)
+        {
+            $logMessage = "Attaching File
+            From: $($message.From)
+            Title: $($message.Subject)"
+            New-SMEXCOEvent -Source "Attach-FileToWorkItem" -EventId 1 -LogMessage $logMessage -Severity "Information"
+        }
+        
         try
         {
             #determine if a File Attachment

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1519,12 +1519,12 @@ function Update-WorkItem ($message, $wiType, $workItemID)
         switch ($wiType)
         {
             "ma" {
-                    $workItem = get-scsmobject -class $maClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
+                    $workItem = Get-SCSMObject -class $maClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
                     $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
                     Attach-FileToWorkItem $message $parentWorkItem
                  }
             "ra" {
-                    $workItem = get-scsmobject -class $raClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
+                    $workItem = Get-SCSMObject -class $raClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
                     $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
                     Attach-FileToWorkItem $message $parentWorkItem
                  }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1521,12 +1521,12 @@ function Update-WorkItem ($message, $wiType, $workItemID)
             "ma" {
                     $workItem = Get-SCSMObject -class $maClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
                     $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
-                    Attach-FileToWorkItem $message $parentWorkItem
+                    Attach-FileToWorkItem $message $parentWorkItem.Name
                  }
             "ra" {
                     $workItem = Get-SCSMObject -class $raClass -filter "Name -eq '$workItemID'" @scsmMGMTParams
                     $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
-                    Attach-FileToWorkItem $message $parentWorkItem
+                    Attach-FileToWorkItem $message $parentWorkItem.Name
                  }
             default { Attach-FileToWorkItem $message $workItemID }
        }


### PR DESCRIPTION
Adding logic to attach a file (function Update-WorkItem) to parent work item when the work item is a manual or review activity. If the work item type is a review or manual activity it will attach the file to the parent work item instead of the work item itself as there is no out-of-box way of viewing attachments to activities, and may not have been intended to do so by Microsoft.

Also introducing a logging event for File Attachments within Attach-FileToWorkItem