### PR TITLE
Search KB Endpoint

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2873,9 +2873,9 @@ function Search-AvailableCiresonPortalOfferings ($searchQuery, $ciresonPortalUse
 }
 
 #search the Cireson KB based on content from a New Work Item and notify the Affected User
-function Search-CiresonKnowledgeBase ($searchQuery, $ciresonPortalUser)
+function Search-CiresonKnowledgeBase ($searchQuery)
 {
-    $kbAPIurl = "api/V3/KnowledgeBase/GetHTMLArticlesFullTextSearch?userId=$($ciresonPortalUser.Id)&searchValue=$searchQuery&isManager=$([bool]$ciresonPortalUser.KnowledgeManager)&userLanguageCode=$($ciresonPortalUser.LanguageCode)"
+    $kbAPIurl = "api/V3/Article/FullTextSearch?&searchValue=$searchQuery"
     if ($ciresonPortalWindowsAuth -eq $true)
     {
         $kbResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$kbAPIurl) -UseDefaultCredentials
@@ -2965,7 +2965,7 @@ function Get-CiresonSuggestionURL
     #call the Suggestion functions passing the search query (work item description/keywords) per the enabled features
     switch ($isSuggestionFeatureUsed)
     {
-        "SuggestKA" {$kbURLs = Search-CiresonKnowledgeBase -searchQuery $($searchQueriesHash["AzureKA"]) -ciresonPortalUser $portalUser}
+        "SuggestKA" {$kbURLs = Search-CiresonKnowledgeBase -searchQuery $($searchQueriesHash["AzureKA"])}
         "SuggestRO" {$requestURLs = Search-AvailableCiresonPortalOfferings -searchQuery $($searchQueriesHash["AzureRO"]) -ciresonPortalUser $portalUser}
     }
     return $kbURLs, $requestURLs


### PR DESCRIPTION
Per Cireson's API documentation, the GetHTMLArticlesFullTextSearch endpoint is deprecated. The FullTextSearch endpoint returns the same values in testing and does not require a Cireson Portal User object to perform a search.