### PR TITLE
don't attempt to retrieve null reviewers

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1993,7 +1993,10 @@ function Update-WorkItem ($message, $wiType, $workItemID)
                     $reviewers = Get-SCSMRelatedObject -SMObject $workItem -Relationship $raHasReviewerRelClass @scsmMGMTParams
                     foreach ($reviewer in $reviewers)
                     {
-                        $reviewingUser = get-scsmobject -class $userClass -filter "id -eq '$((Get-SCSMRelatedObject -SMObject $reviewer -Relationship $raReviewerIsUserRelClass @scsmMGMTParams).id)'" @scsmMGMTParams
+                        $reviewingUser = Get-SCSMRelatedObject -SMObject $reviewer -Relationship $raReviewerIsUserRelClass @scsmMGMTParams
+                        if ($reviewingUser)
+                        {
+                        $reviewingUser = Get-SCSMObject -Id $reviewingUser.Id @scsmMGMTParams
                         $reviewingUserName = $reviewingUser.UserName #it is necessary to store this in its own variable for the AD filters to work correctly
                         $reviewingUserSMTP = Get-SCSMRelatedObject -SMObject $reviewingUser @scsmMGMTParams | ?{$_.displayname -like "*SMTP"} | select-object TargetAddress
 
@@ -2122,6 +2125,7 @@ function Update-WorkItem ($message, $wiType, $workItemID)
                             {
                                 #not a user or a group
                             }
+                        }
                         }
                     }
                     


### PR DESCRIPTION
When obtaining a User from a Reviewer, it's possible the User was not defined in SCSM. Which means when the connector runs against an RA, an error would be thrown to the effect of "Exception Message: Id='' -- Unrecognized Guid format." because Get-SCSMObject would fail to parse a null value.

Now the related object's existence is confirmed before moving forward with the processing.