### PR TITLE
File Attachment Names and Extensions

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2382,11 +2382,11 @@ function Attach-FileToWorkItem ($message, $workItemId)
                 $NewFile.Item($fileAttachmentClass, "Id").Value = [Guid]::NewGuid().ToString()
                 if (!($attachment.DisplayName))
                 {
-                    $NewFile.Item($fileAttachmentClass, "DisplayName").Value = $attachment.Name
+                    $NewFile.Item($fileAttachmentClass, "DisplayName").Value = $attachment.Name.Split([IO.Path]::GetInvalidFileNameChars()) -join ""
                 }
                 else
                 {
-                    $NewFile.Item($fileAttachmentClass, "DisplayName").Value = $attachment.DisplayName
+                    $NewFile.Item($fileAttachmentClass, "DisplayName").Value = $attachment.DisplayName.Split([IO.Path]::GetInvalidFileNameChars()) -join ""
                 }
                 #optional, use Azure Cognitive Services Vision, OCR, or Speech to set the Description property on the file
                 try

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2391,13 +2391,27 @@ function Attach-FileToWorkItem ($message, $workItemId)
                 #optional, use Azure Cognitive Services Vision, OCR, or Speech to set the Description property on the file
                 try
                 {
+                    #The $Attachment does not have an Extension property, attempt to generate one for the SCSM File Object from the $Attachment.Name
                     if (!($attachment.Extension))
                     {
                         $fileExtensionArrayPosition = $attachment.Name.Split(".").Length - 1
                         $NewFile.Item($fileAttachmentClass, "Extension").Value = "." + $attachment.Name.Split(".")[$fileExtensionArrayPosition]
                     }
-                    $fileExtensionArrayPosition = $attachment.Name.Split(".").Length - 1
-                    $NewFile.Item($fileAttachmentClass, "Extension").Value = "." + $attachment.Name.Split(".")[$fileExtensionArrayPosition]
+                    #The $Attachment has a Extension defined, set the SCSM File Attachment object's Extension property based on the Attachment's Extension
+                    else
+                    {
+                        if ($attachment.Extension.StartsWith("."))
+                        {
+                            $NewFile.Item($fileAttachmentClass, "Extension").Value = $attachment.Extension
+                        }
+                        else
+                        {
+                            $NewFile.Item($fileAttachmentClass, "Extension").Value = "." + $attachment.Extension
+                        }
+                        
+                    }
+
+                    #See if the File Extension is a known image type and if Azure Vision is being used
                     if (((".png", ".jpg", ".jpeg", ".bmp", ".gif") -contains $NewFile.Item($fileAttachmentClass, "Extension").Value) -and ($enableAzureVision))
                     {
                         $azureVisionResult = Get-AzureEmailImageAnalysis -imageToEvalute $AttachmentContent
@@ -2427,6 +2441,7 @@ function Attach-FileToWorkItem ($message, $workItemId)
                             $NewFile.Item($fileAttachmentClass, "Description").Value = "Tags:$($azureVisionTags)"
                         }
                     }
+                    #See if the File Extension is a known audio type and if Azure Speech is being used
                     if (((".wav", ".ogg") -contains $NewFile.Item($fileAttachmentClass, "Extension").Value) -and ($enableAzureSpeech))
                     {
                         $NewFile.Item($fileAttachmentClass, "Description").Value = (Get-AzureSpeechEmailAudioText -audioFileToEvaluate $attachmentContent).DisplayText


### PR DESCRIPTION
The Attach-FileToWorkItem function should remove illegal characters from the File Name so that when an Analyst attempts to view/save the file afterwards the:
- console doesn't crash
- portal doesn't throw an error about illegal characters in the file path

The Attach-FileToWorkItem function should not attempt to re-write the Extension property when one has already been set.
- This issue is pronounced in the case of an Attached Outlook Item (emails/meetings).

Opening as a result of #324 