### PR TITLE
file management, emails and attachments

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2480,7 +2480,6 @@ function Add-FileToSCSMObject ($attachment, $smobject)
                 if ($attachedByUser)
                 {
                     New-SCSMRelationshipObject -Source $NewFile -Relationship $fileAddedByUserRelClass -Target $attachedByUser @scsmMGMTParams -Bulk
-                    $existingAttachmentsCount += 1
                 }
             }
         }


### PR DESCRIPTION
- rather than process the attachments within the Add-FileToSCSMObject function, it now just accepts a single file object. Calls to the function have been updated so looping occurs outside of the function.
- Add-EmailToWorkItem has been renamed to Add-EmailToSCSMObject
- both Add-FileToSCSMObject and Add-EmailToSCSMObject have been slightly refactored so when adding an email/files to a Config Item the logic to check for File Attachment Criteria on Work Items is not applied
