### PR TITLE
Custom Rules, Else

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -5090,8 +5090,8 @@ foreach ($message in $inbox)
                 
                     #mark the message as read on Exchange, move to deleted items
                     $message.IsRead = $true
-                    $hideInVar01 = $message.Update([Microsoft.Exchange.WebServices.Data.ConflictResolutionMode]::AutoResolve)
-                    if ($deleteAfterProcessing){$hideInVar02 = $message.Move([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::DeletedItems)} 
+                    $message.Update([Microsoft.Exchange.WebServices.Data.ConflictResolutionMode]::AutoResolve) | Out-Null
+                    if ($deleteAfterProcessing){$message.Move([Microsoft.Exchange.WebServices.Data.WellKnownFolderName]::DeletedItems) | Out-Null}
                 }
             }
         }


### PR DESCRIPTION
When Custom Rules are being used and a Custom Message Class has been identified, it needs to fall into the ELSE of the core processing loop.