### PR TITLE
Another way to get user by email

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2501,6 +2501,10 @@ function Get-SCSMUserByEmailAddress ($EmailAddress)
     }
     else
     {
+        $username = $EmailAddress.Split("@")[0]
+        $domainAndTLD = $EmailAddress.Split("@")[1]
+        $existingUser = Get-SCSMObject -Class $domainUserClass -Filter "Username -eq '$username' -and Domain -eq '$domainAndTLD'";
+        if ($existingUser) {return $existingUser}
         if ($loggingLevel -ge 2){New-SMEXCOEvent -Source "Get-SCSMUserByEmailAddress" -EventId 1 -LogMessage "Address: $EmailAddress could not be matched to a user in SCSM" -Severity "Warning"}
         return $null
     }


### PR DESCRIPTION
If the user can't be retrieved via the notification object, they could be retrieved by parsing the email (assuming they were created with SMLets format).