### PR TITLE
Get-CiresonPortalAPIToken credential object

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2819,21 +2819,15 @@ function Get-CiresonPortalAPIToken
     if ($scsmLFXConfigMP.GetRules() | Where-Object {($_.Name -eq "SMLets.Exchange.Connector.15d8b765a2f8b63ead14472f9b3c12f0")} | Select-Object Enabled -ExpandProperty Enabled)
     {
         $ciresonPortalCredentials = @{"username" = "$ciresonPortalRunAsUsername"; "password" = "$ciresonPortalRunAsPassword"; "languagecode" = "ENU" } | ConvertTo-Json
-        #make a credential object
-        [securestring]$cpSecPW = ConvertTo-SecureString $ciresonPortalRunAsPassword -AsPlainText -Force
-        [pscredential]$ciresonPortalCred = New-Object System.Management.Automation.PSCredential ($ciresonPortalRunAsUsername, $cpSecPW)
     }
     else
     {
         $ciresonPortalCredentials = @{"username" = "$ciresonPortalUsername"; "password" = "$ciresonPortalPassword"; "languagecode" = "ENU" } | ConvertTo-Json
-        #make a credential object
-        [securestring]$cpSecPW = ConvertTo-SecureString $ciresonPortalPassword -AsPlainText -Force
-        [pscredential]$ciresonPortalCred = New-Object System.Management.Automation.PSCredential ($ciresonPortalUsername, $cpSecPW)
     }
 
     #make the call to the portal to retrieve a token
     $ciresonTokenURL = $ciresonPortalServer+"api/V3/Authorization/GetToken"
-    $ciresonAPIToken = Invoke-RestMethod -uri $ciresonTokenURL -Method post -Body $ciresonPortalCredentials -Credential $ciresonPortalCred
+    $ciresonAPIToken = Invoke-RestMethod -uri $ciresonTokenURL -Method post -Body $ciresonPortalCredentials
     $ciresonAPIToken = "Token" + " " + $ciresonAPIToken
 
     return $ciresonAPIToken


### PR DESCRIPTION
creating a PS Credential object and/or using ConvertTo-SecureString is not necessary to make the API call to retrieve a token