### PR TITLE
Azure Cloud Instance, string vs. enum

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -300,7 +300,7 @@ $ExchangeEndpoint = "$($smexcoSettingsMP.ExchangeAutodiscoverURL)"
 $UseExchangeOnline = $smexcoSettingsMP.UseExchangeOnline
 $AzureClientID = "$($smexcoSettingsMP.AzureClientID)"
 $AzureTenantID = "$($smexcoSettingsMP.AzureTenantID)"
-$AzureCloudInstance = "$($smexcoSettingsMP.AzureCloudInstance)"
+$AzureCloudInstance = $($smexcoSettingsMP.AzureCloudInstance)
 #determine which Azure Cloud (if any) is being used to set required URLs
 switch ($AzureCloudInstance.Name)
 {


### PR DESCRIPTION
the enum value should not be contained in quotes as this returns a string instead of the enum object