### PR TITLE
Get-SCSMUserByEmailAddress cannot find mail addresses with a dash

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1538,7 +1538,7 @@ function Update-WorkItem ($message, $wiType, $workItem)
                     $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
                     $message.Attachments | Foreach-Object {Add-FileToSCSMObject -attachment $_ -smobject $parentWorkItem}
                  }
-            default { $message.Attachments | Foreach-Object {Add-FileToSCSMObject -attachment $_ -smobject $parentWorkItem} }
+            default { $message.Attachments | Foreach-Object {Add-FileToSCSMObject -attachment $_ -smobject $workItem} }
        }
     }
     #show the user who will perform the update and the [action] they are taking. If there is no [action] it's just a comment

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1538,7 +1538,7 @@ function Update-WorkItem ($message, $wiType, $workItem)
                     $parentWorkItem = Get-SCSMWorkItemParent -WorkItemGUID $workItem.Get_Id().Guid
                     $message.Attachments | Foreach-Object {Add-FileToSCSMObject -attachment $_ -smobject $parentWorkItem}
                  }
-            default { $message.Attachments | Foreach-Object {Add-FileToSCSMObject -attachment $_ -smobject $workItem} }
+            default { $message.Attachments | Foreach-Object {Add-FileToSCSMObject -attachment $_ -smobject $parentWorkItem} }
        }
     }
     #show the user who will perform the update and the [action] they are taking. If there is no [action] it's just a comment

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2518,7 +2518,7 @@ function Get-WorkItem ($workItemID, $workItemClass)
 
 function Get-SCSMUserByEmailAddress ($EmailAddress)
 {
-    $userSMTPNotification = Get-SCSMObject -Class $notificationClass -Filter "TargetAddress -eq '$EmailAddress'" @scsmMGMTParams | sort-object lastmodified -Descending | select-object -first 1
+    $userSMTPNotification = Get-SCSMObject -Class $notificationClass -Filter "TargetAddress -eq $EmailAddress" @scsmMGMTParams | sort-object lastmodified -Descending | select-object -first 1
     if ($userSMTPNotification)
     {
         $user = get-scsmobject -id (Get-SCSMRelationshipObject -ByTarget $userSMTPNotification @scsmMGMTParams).sourceObject.id @scsmMGMTParams


### PR DESCRIPTION
If mail address contains a dash, the address won't be found in SCSM.
Example: Get-SCSMObject -Class $notificationClass -Filter "TargetAddress -eq 'scott-jimmy.clarskon@contoso.com'" won't return anything.
But: Get-SCSMObject -Class $notificationClass -Filter "TargetAddress -eq scott-jimmy.clarskon@contoso.com" will work.