### PR TITLE
usage, isVerifiedSig

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -4899,10 +4899,11 @@ foreach ($message in $inbox)
         if ($decryptedBody.ContentType.MimeType -eq "application/x-pkcs7-mime")
         {
             #check to see if there are attachments
-            $isVerifiedSig = $decryptedBody.Verify($certStore, [ref]$decryptedBody)
+            $digitalSignatures = $decryptedBody.Verify($certStore, [ref]$decryptedBody)
+            
             $decryptedBodyWOAttachments = $decryptedBody | Where-Object{($_.isattachment -eq $false)}
             $decryptedAttachments = if ($decryptedBody.ContentType.MimeType -eq "multipart/alternative") {$decryptedBody | Where-Object{$_.isattachment -eq $true}} else {$decryptedBody | Select-Object -skip 1}
-
+            $digitalSignatures | Foreach-Object {if ($_.Verify()){New-SMEXCOEvent -Source "Cryptography" -EventID 2 -Severity "Information" -LogMessage "Digital signature is valid"} else {New-SMEXCOEvent -Source "Cryptography" -EventID 3 -Severity "Warning" -LogMessage "Digital signature could not be verified"}}
             $email = [PSCustomObject] @{
                 From              = $response.From.address
                 To                = $response.To

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -4900,7 +4900,17 @@ foreach ($message in $inbox)
         {
             #check to see if there are attachments
             $digitalSignatures = $decryptedBody.Verify($certStore, [ref]$decryptedBody)
-            
+            $digitalSignatures | Foreach-Object {
+                if ($_.Verify()) {
+                    if ($loggingLevel -ge 4)
+                    { New-SMEXCOEvent -Source "Cryptography" -EventID 2 -Severity "Information" -LogMessage "Digital signature is valid" }
+                }
+                else {
+                    if ($loggingLevel -ge 2) {
+                        New-SMEXCOEvent -Source "Cryptography" -EventID 3 -Severity "Warning" -LogMessage "Digital signature could not be verified"
+                    }
+                }
+            }
             $decryptedBodyWOAttachments = $decryptedBody | Where-Object{($_.isattachment -eq $false)}
             $decryptedAttachments = if ($decryptedBody.ContentType.MimeType -eq "multipart/alternative") {$decryptedBody | Where-Object{$_.isattachment -eq $true}} else {$decryptedBody | Select-Object -skip 1}
             $digitalSignatures | Foreach-Object {if ($_.Verify()){New-SMEXCOEvent -Source "Cryptography" -EventID 2 -Severity "Information" -LogMessage "Digital signature is valid"} else {New-SMEXCOEvent -Source "Cryptography" -EventID 3 -Severity "Warning" -LogMessage "Digital signature could not be verified"}}


### PR DESCRIPTION
Per MimeKit documentation, [the output of the following is of type DigitalSignatureCollection](https://www.mimekit.net/docs/html/M_MimeKit_Cryptography_ApplicationPkcs7Mime_Verify.htm):

```powershell
$isVerifiedSig = $decryptedBody.Verify($certStore, [ref]$decryptedBody)
```

And [documentation per DigitalSignatureCollection](https://www.mimekit.net/docs/html/T_MimeKit_Cryptography_DigitalSignatureCollection.htm) states:
> When verifying a digitally signed MIME part such as a [MultipartSigned](https://www.mimekit.net/docs/html/T_MimeKit_Cryptography_MultipartSigned.htm) or a [ApplicationPkcs7Mime](https://www.mimekit.net/docs/html/T_MimeKit_Cryptography_ApplicationPkcs7Mime.htm), you will get back a collection of digital signatures. Typically, a signed message will only have a single signature (created by the sender of the message), but it is possible for there to be multiple signatures.

As a result, $isVerifiedSig is not the best choice of variable naming and as such is moving to $digitalSignatures along with a couple logging events.