### PR TITLE
SCOM Distributed App Health, sender address

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -4274,7 +4274,7 @@ function Get-SCOMAuthorizedRequester ($EmailAddress)
 function Get-SCOMDistributedAppHealth ($message)
 {
     #determine if the sender is authorized to make SCOM Health requests
-    $isAuthorized = Get-SCOMAuthorizedRequester -EmailAddress $message.From.Address
+    $isAuthorized = Get-SCOMAuthorizedRequester -EmailAddress $message.From
 
     if (($isAuthorized -eq $true))
     {


### PR DESCRIPTION
Incorrect variable is used when retrieving a user by their email address