### PR TITLE
Single Instance Pickers

### DIFF
--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -3070,16 +3070,16 @@ namespace SMLetsExchangeConnectorSettingsUI
             catch { this.IsCiresonAnnouncementsEnabled = false; }
 
             this.SCSMApprovedAnnouncers = emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementUsers"].ToString();
-            try
+            if (emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementGroupGUID"].Value != null)
             {
-                this.SCSMApprovedGroupGUID = (Guid)emoAdminSetting[null, "SCSMApprovedAnnouncementGroupGUID"].Value;
-                EnterpriseManagementObject ScsmApprovedGroupEmoObject;
-                ScsmApprovedGroupEmoObject = (EnterpriseManagementObject)emg.EntityObjects.GetObject<EnterpriseManagementObject>(this.SCSMApprovedGroupGUID, ObjectQueryOptions.Default);
-                this.SCSMApprovedGroupDisplayName = "CURRENT ANNOUNCEMENT GROUP: " + ScsmApprovedGroupEmoObject.DisplayName;
-            }
-            catch
-            {
-                this.SCSMApprovedGroupDisplayName = "NO ANNOUNCEMENT GROUP DEFINED";
+                try
+                {
+                    this.SCSMApprovedAnnouncementGroup = ConsoleContextHelper.Instance.GetInstance((Guid)emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementGroupGUID"].Value);
+                }
+                catch
+                {
+                    //"NO ANNOUNCEMENT GROUP DEFINED";
+                }
             }
 
             //SCOM Integration

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -3759,8 +3759,15 @@ namespace SMLetsExchangeConnectorSettingsUI
             }
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementUsers"].Value = this.SCSMApprovedAnnouncers;
             //if the Announcement group is set, don't null it
-            try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementGroupGUID"].Value = this.SCSMApprovedAnnouncementGroup["Id"]; }
-            catch { }
+            if (this.SCSMApprovedAnnouncementGroup != null)
+            {
+                try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementGroupGUID"].Value = this.SCSMApprovedAnnouncementGroup["Id"]; }
+                catch { }
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCSMApprovedAnnouncementGroupGUID"].Value = null;
+            }
 
             //SCOM Integration
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "EnableSCOMIntegration"].Value = this.IsSCOMIntegrationEnabled;

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/AdminSettingsWizardData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -12,6 +12,7 @@ using Microsoft.Win32;
 using Microsoft.EnterpriseManagement.ConnectorFramework;
 using System.Xml;
 using System.Globalization;
+using Microsoft.EnterpriseManagement.UI.Extensions.Shared;
 
 namespace SMLetsExchangeConnectorSettingsUI
 {
@@ -3087,16 +3088,16 @@ namespace SMLetsExchangeConnectorSettingsUI
             this.SCOMServer = emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMmgmtServer"].ToString();
             this.AuthorizedSCOMApproverType = emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedMemberType"].ToString();
             this.AuthorizedSCOMUsers = emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedUsers"].ToString();
-            try
+            if (emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedGroupGUID"].Value != null)
             {
-                this.SCOMApprovedGroupGUID = (Guid)emoAdminSetting[null, "SCOMApprovedGroupGUID"].Value;
-                EnterpriseManagementObject ScomApprovedGroupEmoObject;
-                ScomApprovedGroupEmoObject = (EnterpriseManagementObject)emg.EntityObjects.GetObject<EnterpriseManagementObject>(this.SCOMApprovedGroupGUID, ObjectQueryOptions.Default);
-                this.SCOMApprovedGroupDisplayName = "CURRENT APPROVED GROUP: " + ScomApprovedGroupEmoObject.DisplayName;
-            }
-            catch
-            {
-                this.SCOMApprovedGroupDisplayName = "NO SCOM GROUP DEFINED";
+                try
+                {
+                    this.SCOMApprovedGroup = ConsoleContextHelper.Instance.GetInstance((Guid)emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedGroupGUID"].Value);
+                }
+                catch
+                {
+                    //"NO SCOM GROUP DEFINED";
+                }
             }
 
             //Artificial Intelligence - Cognitive Services
@@ -3767,8 +3768,15 @@ namespace SMLetsExchangeConnectorSettingsUI
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedMemberType"].Value = this.AuthorizedSCOMApproverType;
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedUsers"].Value = this.AuthorizedSCOMUsers;
             //if the SCOM approved group is set, don't null it
-            try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedGroupGUID"].Value = this.SCOMApprovedGroup["Id"]; }
-            catch { }
+            if (this.SCOMApprovedGroup != null)
+            {
+                try { emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedGroupGUID"].Value = this.SCOMApprovedGroup["Id"]; }
+                catch { }
+            }
+            else
+            {
+                emoAdminSetting[smletsExchangeConnectorSettingsClass, "SCOMApprovedGroupGUID"].Value = null;
+            }
 
             //Artifical Intelligence - enabled/disabled
             emoAdminSetting[smletsExchangeConnectorSettingsClass, "EnableArtificialIntelligence"].Value = this.IsArtificialIntelligenceEnabled;

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/AnnouncementsForm.xaml
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/AnnouncementsForm.xaml
@@ -1,4 +1,4 @@
-﻿<wpfwiz:WizardRegularPageBase x:Class="SMLetsExchangeConnectorSettingsUI.AnnouncementsForm" 
+<wpfwiz:WizardRegularPageBase x:Class="SMLetsExchangeConnectorSettingsUI.AnnouncementsForm" 
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -55,7 +55,6 @@
             <TextBox Height="50" x:Name="txtApprovedMember" Text="{Binding SCSMApprovedAnnouncers}" IsEnabled="{Binding ElementName=chkAnnouncementIntegration, Path=IsChecked}" TextWrapping="Wrap"/>
             <Label Margin="0,0,0,0" Content="Select the AD group approved for creating Announcements" />
             <Custom:SingleInstancePicker IsEnabled="{Binding ElementName=chkAnnouncementIntegration, Path=IsChecked}" Instance="{Binding SCSMApprovedAnnouncementGroup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" BaseClassId="E2386B9B-5364-E438-A317-93836B979C56" Margin="0,0,10,0" />
-            <Label Margin="0,0,0,0" Content="{Binding SCSMApprovedGroupDisplayName}" />
         </StackPanel>
     </Grid>
-</wpfwiz:WizardRegularPageBase> 
+</wpfwiz:WizardRegularPageBase>

--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/SCOMIntegrationForm.xaml
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/SCOMIntegrationForm.xaml
@@ -1,4 +1,4 @@
-﻿<wpfwiz:WizardRegularPageBase 
+<wpfwiz:WizardRegularPageBase 
             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
             xmlns:sys="clr-namespace:System;assembly=mscorlib"
@@ -36,8 +36,10 @@
                 <TextBlock Margin="10,10,0,0" Text="Enter a comma seperated list of individual approvers (email addresses)" TextWrapping="Wrap" />
                 <TextBox Height="50" x:Name="txtApprovedMember" Text="{Binding AuthorizedSCOMUsers}" IsEnabled="{Binding IsChecked, ElementName=chkSCOMIntegrationEnabled}" TextWrapping="Wrap" Margin="10,0" />
                 <Label Margin="10,0,0,0" Content="Select the AD group approved for requesting health" />
-                <Custom:SingleInstancePicker IsEnabled="{Binding IsChecked, ElementName=chkSCOMIntegrationEnabled}" Instance="{Binding SCOMApprovedGroup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" BaseClassId="E2386B9B-5364-E438-A317-93836B979C56" Margin="10,0" />
-                <Label Margin="0,0,0,0" Content="{Binding SCOMApprovedGroupDisplayName}" Height="24" />
+                <Custom:SingleInstancePicker Margin="10,0"
+                    IsEnabled="{Binding IsChecked, ElementName=chkSCOMIntegrationEnabled}"
+                    BaseClassId="E2386B9B-5364-E438-A317-93836B979C56"
+                    Instance="{Binding SCOMApprovedGroup, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" />
             </StackPanel>
         </ScrollViewer>
     </Grid>


### PR DESCRIPTION
The control (single instance picker) used to get/set the SCOM Group or Announcement Group no longer makes use of a Label to show the configured group.