### PR TITLE
Start to Finish Logging

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1,3 +1,4 @@
+$startTime = Get-Date
 <#
 .SYNOPSIS
 Provides SCSM Exchange Connector functionality through PowerShell
@@ -4541,7 +4542,7 @@ $inboxFilterString = [scriptblock]::Create("$inboxFilterString")
 
 #filter the inbox
 $inbox = $exchangeService.FindItems($inboxFolder.Id,$searchFilter,$itemView) | where-object $inboxFilterString | Sort-Object DateTimeReceived
-if (($loggingLevel -ge 1)-and($inbox.Count -ge 1)){New-SMEXCOEvent -Source "General" -EventId 2 -LogMessage "Messages to Process: $($inbox.Count)" -Severity "Information"; $messagesProcessed = 0}
+if (($loggingLevel -ge 1)){New-SMEXCOEvent -Source "General" -EventId 2 -LogMessage "Messages to Process: $($inbox.Count)" -Severity "Information"; $messagesProcessed = 0}
 # Custom Event Handler
 if ($ceScripts) { Invoke-OnOpenInbox }
 
@@ -5124,4 +5125,15 @@ foreach ($message in $inbox)
 
     #increment the number of messages processed if logging is enabled
     if ($loggingLevel -ge 1){$messagesProcessed++; New-SMEXCOEvent -Source "General" -EventId 3 -LogMessage "Processed: $messagesProcessed of $($inbox.Count)" -Severity "Information"}
+}
+
+#log the total number of messages processed and the connector's total run time
+if ($loggingLevel -ge 1)
+{
+    $endTime = Get-Date
+    $runtime = $endTime - $startTime
+    New-SMExcoEvent -Source "General" -EventID 6 -Severity "Information" -LogMessage "Processed $($inbox.Count) messages in:
+    Minutes: $($runtime.TotalMinutes)
+    Seconds: $($runtime.TotalSeconds)
+    Milliseconds: $($runtime.TotalMilliseconds)"
 }


### PR DESCRIPTION
Previously if there were no messages to processes, the event order would be (at a minimum)
- 0 = Successfully connected to Exchange
- 5 = Filtering Mailbox on:...

There was no indication that there were zero messages to process and/or that Event 5 was the "last" event one would see for a run of the connector. As such, the logging _could be_ misinterpreted as the connector not successfully completing a run.

This change removes that uncertainty as the event is now logged regardless of the number of messages to process as well as introducing event 6 which shows the total runtime of the connector for a given number of messages. Now the minimum logging order is
- 0 = Successfully connected to Exchange
- 5 = Filtering Mailbox on:...
- 2 = Messages to Process: _**X**_
- 6 = Processed _**X**_ messages in:
    Minutes: _total minutes_
    Seconds: _total seconds_
    Milliseconds: _total milliseconds_

Which is more representative of a start, process, and finish of the connector.