### PR TITLE
Github Actions - MSBuild, Checkout, Badges, and Download Artifact

### DIFF
--- a/.github/workflows/BuildDev.yml
+++ b/.github/workflows/BuildDev.yml
@@ -18,7 +18,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE, so job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           ref: dev
 

--- a/.github/workflows/BuildDev.yml
+++ b/.github/workflows/BuildDev.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Add MSBuild to environment path
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1.3
 
       # copy dependencies over
       - name: Copy Dependencies folder from the repo to Build for MP signing and show them

--- a/.github/workflows/BuildPrimary.yml
+++ b/.github/workflows/BuildPrimary.yml
@@ -18,7 +18,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE, so job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           ref: primary
 

--- a/.github/workflows/BuildPrimary.yml
+++ b/.github/workflows/BuildPrimary.yml
@@ -24,7 +24,7 @@ jobs:
 
       # Add MSBuild to environment path
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1.3
 
       # copy dependencies over
       - name: Copy Dependencies folder from the repo to Build for MP signing and show them

--- a/.github/workflows/PSScriptAnalyzer.yml
+++ b/.github/workflows/PSScriptAnalyzer.yml
@@ -37,7 +37,7 @@ jobs:
               echo "ERRORS=$errorCount" | Out-File -FilePath $Env:GITHUB_ENV -Encoding utf-8 -Append
 
           - name: Create Error Badge for PSScriptAnalyzer Result
-            uses: schneegans/dynamic-badges-action@v1.4.0
+            uses: schneegans/dynamic-badges-action@v1.6.0
             with:
               auth: ${{ secrets.SMEXCOSCRIPTANALYZERGIST }}
               gistID: a85ec65858e3065359d1d6a9d122e723
@@ -47,7 +47,7 @@ jobs:
               color: red
 
           - name: Create Warning Badge for PSScriptAnalyzer Result
-            uses: schneegans/dynamic-badges-action@v1.4.0
+            uses: schneegans/dynamic-badges-action@v1.6.0
             with:
               auth: ${{ secrets.SMEXCOSCRIPTANALYZERGIST }}
               gistID: a85ec65858e3065359d1d6a9d122e723
@@ -57,7 +57,7 @@ jobs:
               color: yellow
 
           - name: Create Info Badge for PSScriptAnalyzer Result
-            uses: schneegans/dynamic-badges-action@v1.4.0
+            uses: schneegans/dynamic-badges-action@v1.6.0
             with:
               auth: ${{ secrets.SMEXCOSCRIPTANALYZERGIST }}
               gistID: a85ec65858e3065359d1d6a9d122e723

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -117,7 +117,7 @@ jobs:
           prerelease: ${{ github.event.inputs.prerelease }}
 
       # download the Artifacts to Ubuntu that were uploaded in the Windows build step
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v3.0.2
         id: download #this will be used as a variable
         with:
            name: SMletsExchangeConnector

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -25,7 +25,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out repository under $GITHUB_WORKSPACE, so job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3.3.0
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/buildrelease.yml
+++ b/.github/workflows/buildrelease.yml
@@ -31,7 +31,7 @@ jobs:
 
       # Add MSBuild to environment path
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.1.3
 
       # copy dependencies over
       - name: Copy Dependencies folder from the repo to Build for MP signing and show them

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3.3.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
@@ -67,7 +67,7 @@ jobs:
 
       # Add MSBuild to environment path
     - name: Add msbuild to PATH
-      uses: microsoft/setup-msbuild@v1.0.2
+      uses: microsoft/setup-msbuild@v1.1.3
 
       # copy dependencies over
     - name: Copy Dependencies folder from the repo to Build for MP signing and show them


### PR DESCRIPTION
**Describe the change**  
Workflows used throughout the repo are being upgraded as they are all Node.js 12 based actions. Per output in all of the workflow runs, node.js12 are deprecated and should be upgraded.
- Updating MSBuild Action version from v1.0.2 to v1.1.3
- Update Checkout action from v2 to v3.3.0
- Update Dynamic Badges from v1.4.0 to v1.6.0
- Update Download Artifact action from from v2 to v3.0.2