### PR TITLE
function best practices

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2613,6 +2613,8 @@ function Get-SCSMUserByEmailAddress
 
 # Nested group membership check inspired by Piotr Lewandowski https://gallery.technet.microsoft.com/scriptcenter/Get-nested-group-15f725f2#content
 function Get-TierMembership {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'UserSamAccountName', Justification = 'False positive')]
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'TierId', Justification = 'False positive')]
     param (
         #The SCSM User who will be determined to be part of the given Tier
         [parameter(Mandatory=$true)]
@@ -3435,6 +3437,7 @@ function Confirm-WorkItem
 
 function Test-EmailPattern
 {
+    [Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'MessageClass', Justification = 'False positive')]
     param (
         #The Exchange message class, e.g. IPM.Note, IPM.Schedule.Meeting.Request, etc.
         [Parameter(Mandatory=$true)]


### PR DESCRIPTION
Standardizing functions used through the connector for consistency and to follow best practice as defined by PSScriptAnalzyer.

- Use dedicated parameter block for all functions
- [Functions have verb that could change state, therefore, the function has to support 'ShouldProcess'](https://learn.microsoft.com/en-us/powershell/utility-modules/psscriptanalyzer/rules/useshouldprocessforstatechangingfunctions?view=ps-modules). As a result, functions updated with this now support the PowerShell -WhatIf switch
- The cmdlet 'Get-CiresonSuggestionURL' returns an object of type ' System.Object []' [but this type is not declared in the OutputType attribute.](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_functions_outputtypeattribute?view=powershell-7.3)
- [PSScriptAnalyzer does not capture parameter usage within a [scriptblock]](https://github.com/PowerShell/PSScriptAnalyzer/issues/1472) causing a false positive