### PR TITLE
fix for templates with activities

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -4581,7 +4581,8 @@ function Update-SCSMPropertyCollection
 {
     [CmdletBinding(SupportsShouldProcess=$true)]
     Param (
-        [Microsoft.EnterpriseManagement.Configuration.ManagementPackObjectTemplateObject]$Object =$(throw "Please provide a valid template object")
+        [Microsoft.EnterpriseManagement.Configuration.ManagementPackObjectTemplateObject]$Object =$(throw "Please provide a valid template object"),
+        $Alias
     )
 
     if($PSCmdlet.ShouldProcess("$($Object.DisplayName)"))


### PR DESCRIPTION
In #431 the $alias parameter was removed. This parameter is required to use Templates that have 1 or more Activities on them.