### PR TITLE
Fix for Templates with nested Activities

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -4611,7 +4611,7 @@ function Update-SCSMPropertyCollection
             {
                 foreach ($obj in $Object.ObjectCollection)
                 {
-                    Update-SCSMPropertyCollection -Object $obj
+                    Update-SCSMPropertyCollection -Object $obj -Alias $alias
                 }
             }
         }


### PR DESCRIPTION
Added -Alias $alias to the recursive Update-SCSMPropertyCollection call, so it takes nested activities into account

