### PR TITLE
Fix for Action log comments length > 4000

### DIFF
--- a/.github/workflows/PSScriptAnalyzerPullRequest.yml
+++ b/.github/workflows/PSScriptAnalyzerPullRequest.yml
@@ -1,73 +1,49 @@
-name: PSScriptAnalyzer on Pull Request
+name: PSScriptAnalyzer
 on:
   [pull_request]
 jobs:
     lint-with-PSScriptAnalyzer:
-        name: Install and Run PSScriptAnalyzer
+        name: Linting
         runs-on: ubuntu-latest
-
-        permissions:
-          pull-requests: write
-
         steps:
           - uses: actions/checkout@v3
 
-          - name: Install PSScriptAnalyzer module
+          - name: Install required modules
             id: InstallPSScriptAnalyzer
             shell: pwsh
             run: |
               Set-PSRepository PSGallery -InstallationPolicy Trusted
               Install-Module PSScriptAnalyzer -ErrorAction Stop
+              Install-Module FormatMarkdownTable -ErrorAction Stop
 
-          - name: Lint with PSScriptAnalyzer. Post Results to Pull Request
-            id: RunPSScriptAnalyzerAndCommentPR
+          - name: Lint with PSScriptAnalyzer
+            id: RunPSScriptAnalyzer
             shell: pwsh
             run: |
-              #### Run PSScriptAnalyzer per VSCode default settings ####
               $ExcludedRules = @('PSAvoidUsingInvokeExpression')
-              Invoke-ScriptAnalyzer -Path smletsExchangeConnector.ps1 -ExcludeRule $ExcludedRules -Outvariable issues
-              $errors   = $issues.Where({($_.Severity -eq 'Error') -or ($_.Severity -eq 'ParseError')})
-              $warnings = $issues.Where({$_.Severity -eq 'Warning'})
-              $info     = $issues.Where({$_.Severity -eq 'Information'})
+              $all = Invoke-ScriptAnalyzer -Path smletsExchangeConnector.ps1 -ExcludeRule $ExcludedRules
+              $errors   = $all.Where({($_.Severity -eq 'Error') -or ($_.Severity -eq 'ParseError')})
+              $errorCount = $errors.Count
+              $warnings = $all.Where({$_.Severity -eq 'Warning'})
+              $warningCount = $warnings.Count
+              $info     = $all.Where({$_.Severity -eq 'Information'})
+              $infoCount = $info.Count
 
-              #### Retrieve the Pull Request that triggered this Action ####
-              $ghEvent     = Get-Content -Path $env:GITHUB_EVENT_PATH | ConvertFrom-Json
-              $pullRequestURL = $ghEvent.pull_request.comments_url
+              #Format the Error table
+              $errors = $errors | Format-MarkdownTableListStyle RuleName, Line, Message
+              "## :stop_sign: $errorCount Error(s)" >> $env:GITHUB_STEP_SUMMARY
+              $errors >> $env:GITHUB_STEP_SUMMARY
 
-              #### Prepare the message to comment ####
-              $nl = [Environment]::NewLine
-              $comment  = '**PSScriptAnalyzer results:**'
-              $comment += $nl + $nl
-              $comment += '{0}<details><summary>EmojiError [{1}] Errors, EmojiWarn [{2}] Warnings, EmojiInfo [{3}] Information</summary><p>{4}{5}```' -f $nl, $errors.Count, $warnings.Count, $info.Count, $nl, $nl
+              #Format the Warning table
+              $warnings = $warnings | Format-MarkdownTableListStyle RuleName, Line, Message
+              "## :warning: $warningCount Warning(s)" >> $env:GITHUB_STEP_SUMMARY
+              $warnings >> $env:GITHUB_STEP_SUMMARY
 
-              if ($errors.Count -gt 0) {
-                  $comment += $nl + ($errors | Format-List -Property RuleName, Severity, ScriptName, Line, Message | Out-String -Width 80).Trim()
-                }
-              if ($warnings.Count -gt 0) {
-                  $comment += $nl+ $nl + ($warnings | Format-List -Property RuleName, Severity, ScriptName, Line, Message | Out-String -Width 80).Trim()
-                }
-              if ($info.Count -gt 0) {
-                  $comment += $nl + $nl + ($info | Format-List -Property RuleName, Severity, ScriptName, Line, Message | Out-String -Width 80).Trim()
-                }
-              $comment += '{0}{1}```{2}</p></details>' -f $nl, $nl, $nl
+              #Format the Info table
+              $info = $info | Format-MarkdownTableListStyle RuleName, Line, Message
+              "## :information_source: $infoCount Info" >> $env:GITHUB_STEP_SUMMARY
+              $info >> $env:GITHUB_STEP_SUMMARY
 
-              #### Leave a comment on the PR ####
-              if ($errors.Count -ge 0 -or $warnings.Count -ge 0 -or $info.Count -ge 0)
-              {
-                $header = @{Authorization = "Bearer ${{ secrets.GITHUB_TOKEN }}"}
-                $commentBody = $(@{body = $comment} | ConvertTo-Json )
-
-                # GitHub Actions includes color, remove it from the JSON
-                $commentBody = $commentBody.Replace("\u001b[0m","").Replace("\u001b[32;1m","")
-
-                # Replace Error, Warning, Info with Emojis
-                $infoEmoji = ":information_source:"
-                $warningEmoji = ":warning:"
-                $errorEmoji = ":stop_sign:"
-                $commentBody = $commentBody -replace "\bEmojiInfo\b", $infoEmoji
-                $commentBody = $commentBody -replace "\bEmojiWarn\b", $warningEmoji
-                $commentBody = $commentBody -replace "\bEmojiError\b", $errorEmoji
-
-                # Post the Comment to the Pull Request
-                Invoke-RestMethod -uri $pullRequestURL -method "POST" -headers $header -body $commentBody -ContentType "application/json"
-              }
+              #either pass or fail
+              if ($errorCount + $warningCount + $infoCount -ge 1){Write-Error "PSScriptAnalyzer found at least 1 Error, Warning, or Information event. View the Summary for details."; exit 1}
+              else {exit 0}

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1555,7 +1555,7 @@ function Update-WorkItem
             $commentToAdd = $message.body
             if ($commentToAdd.length -ge "4000")
             {
-                $commentToAdd.substring(0, 4000)
+                $commentToAdd = $commentToAdd.substring(0, 4000)
             }
         }
         else
@@ -1568,7 +1568,7 @@ function Update-WorkItem
                     $commentToAdd = $message.body
                     if ($commentToAdd.length -ge "4000")
                     {
-                        $commentToAdd.substring(0, 4000)
+                        $commentToAdd = $commentToAdd.substring(0, 4000)
                     }
                 }
                 else
@@ -1576,7 +1576,7 @@ function Update-WorkItem
                     $commentToAdd = $message.Body.substring(0, $fromKeywordPosition)
                     if ($commentToAdd.length -ge "4000")
                     {
-                        $commentToAdd.substring(0, 4000)
+                        $commentToAdd = $commentToAdd.substring(0, 4000)
                     }
                 }
             }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -4611,7 +4611,7 @@ function Update-SCSMPropertyCollection
             {
                 foreach ($obj in $Object.ObjectCollection)
                 {
-                    Update-SCSMPropertyCollection -Object $obj
+                    Update-SCSMPropertyCollection -Object $obj -Alias $alias
                 }
             }
         }


### PR DESCRIPTION
Fixes the assignment of the commenttoadd.substring(0,4000) to the commenttoadd variable
