### PR TITLE
Fix for Update-WorkItem with Comment length > 4000

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -1555,7 +1555,7 @@ function Update-WorkItem
             $commentToAdd = $message.body
             if ($commentToAdd.length -ge "4000")
             {
-                $commentToAdd.substring(0, 4000)
+                $commentToAdd = $commentToAdd.substring(0, 4000)
             }
         }
         else
@@ -1568,7 +1568,7 @@ function Update-WorkItem
                     $commentToAdd = $message.body
                     if ($commentToAdd.length -ge "4000")
                     {
-                        $commentToAdd.substring(0, 4000)
+                        $commentToAdd = $commentToAdd.substring(0, 4000)
                     }
                 }
                 else
@@ -1576,7 +1576,7 @@ function Update-WorkItem
                     $commentToAdd = $message.Body.substring(0, $fromKeywordPosition)
                     if ($commentToAdd.length -ge "4000")
                     {
-                        $commentToAdd.substring(0, 4000)
+                        $commentToAdd = $commentToAdd.substring(0, 4000)
                     }
                 }
             }


### PR DESCRIPTION
Whenever the update-workitem is called with a message, where the length of the body is greater than 4000, the substring(0,4000) function is called, but the result is not written back to the commentToAdd variable - so the full message is further processed, and the action log is not added to the workitem.
