### PR TITLE
move the true/false value for $ceScripts

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -751,16 +751,16 @@ $ceScripts = if($smexcoSettingsMP.FilePathCustomEvents.EndsWith(".ps1"))
         if ($loggingLevel -ge 4)
         {
             New-SMEXCOEvent -Source "CustomEvents" -EventID 0 -Severity "Information" -LogMessage "Custom Events PowerShell loaded successfully" | out-null
-            $true
         }
+        $true
     }
     catch
     {
         if ($loggingLevel -ge 2)
         {
             New-SMEXCOEvent -Source "CustomEvents" -EventID 1 -Severity "Warning" -LogMessage $_.Exception | out-null
-            $false
         }
+        $false
     }
 }
 #endregion #### Configuration ####


### PR DESCRIPTION
$true/$false values are incorrectly tied to the logging level used by the connector. This moves them out of that logic and ensures $ceScripts always has a value