### PR TITLE
Remove "Resolved By User" Relationship when WorkItem is reactivated

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3678,6 +3678,15 @@ function Undo-WorkItemResolution
         "System.WorkItem.Problem" {$enumValue = "ProblemStatusEnum.Active$"; $resName = "Resolution"}
     }
     Set-SCSMObject -SMObject $WorkItem -propertyhashtable @{"Status" = $enumValue; $resName = $null; "ResolutionDescription" = $null; "ResolvedDate" = $null} @scsmMGMTParams;
+    try
+    {
+        $resbyUserObject = Get-SCSMRelationshipObject -BySource $workItem -Filter "RelationshipId -eq '$($workResolvedByUserRelClass.Id)'" @scsmMGMTParams | Remove-scsmrelationship
+    }
+    catch
+    {
+        $logMessage = $_.Exception.Message
+        New-SMEXCOEvent -Source "Update-WorkItem" -EventId 25 -LogMessage $logMessage -Severity "Warning"
+    }
 }
 
 function Read-MIMEMessage

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3678,15 +3678,7 @@ function Undo-WorkItemResolution
         "System.WorkItem.Problem" {$enumValue = "ProblemStatusEnum.Active$"; $resName = "Resolution"}
     }
     Set-SCSMObject -SMObject $WorkItem -propertyhashtable @{"Status" = $enumValue; $resName = $null; "ResolutionDescription" = $null; "ResolvedDate" = $null} @scsmMGMTParams;
-    try
-    {
-        $resbyUserObject = Get-SCSMRelationshipObject -BySource $workItem -Filter "RelationshipId -eq '$($workResolvedByUserRelClass.Id)'" @scsmMGMTParams | Remove-scsmrelationshipobject
-    }
-    catch
-    {
-        $logMessage = $_.Exception.Message
-        New-SMEXCOEvent -Source "Update-WorkItem" -EventId 25 -LogMessage $logMessage -Severity "Warning"
-    }
+    Get-SCSMRelationshipObject -BySource $workItem -Filter "RelationshipId -eq '$($workResolvedByUserRelClass.Id)'" @scsmMGMTParams | Remove-SCSMRelationshipObject
 }
 
 function Read-MIMEMessage

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3680,7 +3680,7 @@ function Undo-WorkItemResolution
     Set-SCSMObject -SMObject $WorkItem -propertyhashtable @{"Status" = $enumValue; $resName = $null; "ResolutionDescription" = $null; "ResolvedDate" = $null} @scsmMGMTParams;
     try
     {
-        $resbyUserObject = Get-SCSMRelationshipObject -BySource $workItem -Filter "RelationshipId -eq '$($workResolvedByUserRelClass.Id)'" @scsmMGMTParams | Remove-scsmrelationship
+        $resbyUserObject = Get-SCSMRelationshipObject -BySource $workItem -Filter "RelationshipId -eq '$($workResolvedByUserRelClass.Id)'" @scsmMGMTParams | Remove-scsmrelationshipobject
     }
     catch
     {


### PR DESCRIPTION
When the Undo-WorkItemResolution is called, the Resolved By User Relationship remains.
Therefor additional code is added to the function