### PR TITLE
Check for existing user in New-CMDBUser

### DIFF
--- a/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/MultipleMailboxes.xaml
+++ b/ManagementPack/2016/SMLetsExchangeConnectorSettingsUI/Forms/MultipleMailboxes.xaml
@@ -43,7 +43,7 @@
                         <GridViewColumn Header="Email Address">
                             <GridViewColumn.CellTemplate>
                                 <DataTemplate>
-                                    <TextBox Text="{Binding MailboxAddress}" Custom:Validation.RegexPattern="^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*@([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,9})$" />
+                                    <TextBox Text="{Binding MailboxAddress}" Custom:Validation.RegexPattern="^([0-9a-zA-Z]([-.\w]*[0-9a-zA-Z])*(\+[0-9a-zA-Z]([-.\w]*[0-9a-zA-Z]))*@([0-9a-zA-Z][-\w]*[0-9a-zA-Z]\.)+[a-zA-Z]{2,9})$" />
                                 </DataTemplate>
                             </GridViewColumn.CellTemplate>
                         </GridViewColumn>

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3678,6 +3678,7 @@ function Undo-WorkItemResolution
         "System.WorkItem.Problem" {$enumValue = "ProblemStatusEnum.Active$"; $resName = "Resolution"}
     }
     Set-SCSMObject -SMObject $WorkItem -propertyhashtable @{"Status" = $enumValue; $resName = $null; "ResolutionDescription" = $null; "ResolvedDate" = $null} @scsmMGMTParams;
+    Get-SCSMRelationshipObject -BySource $workItem -Filter "RelationshipId -eq '$($workResolvedByUserRelClass.Id)'" @scsmMGMTParams | Remove-SCSMRelationshipObject
 }
 
 function Read-MIMEMessage

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3059,15 +3059,22 @@ function Get-CiresonPortalUser
     )
 
     $isAuthUserAPIurl = "api/V3/User/IsUserAuthorized?userName=$username&domain=$domain"
-    if ($ciresonPortalWindowsAuth -eq $true)
-    {
-        $ciresonPortalUserObject = Invoke-RestMethod -Uri ($ciresonPortalServer+$isAuthUserAPIurl) -Method post -UseDefaultCredentials
+    try {
+        if ($ciresonPortalWindowsAuth -eq $true)
+        {
+            $ciresonPortalUserObject = Invoke-RestMethod -Uri ($ciresonPortalServer+$isAuthUserAPIurl) -Method post -UseDefaultCredentials
+        }
+        else
+        {
+            $ciresonPortalUserObject = Invoke-RestMethod -Uri ($ciresonPortalServer+$isAuthUserAPIurl) -Method post -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
+        }
+        if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-CiresonPortalUser" -EventID 0 -Severity Information -LogMessage "User/Sender found in Cireson Portal"}
+        return $ciresonPortalUserObject
     }
-    else
-    {
-        $ciresonPortalUserObject = Invoke-RestMethod -Uri ($ciresonPortalServer+$isAuthUserAPIurl) -Method post -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
+    catch {
+        if ($loggingLevel -ge 3) {New-SMEXCOEvent -Source "Get-CiresonPortalUser" -EventID 1 -Severity Error -LogMessage $_.Exception}
+        return $null
     }
-    return $ciresonPortalUserObject
 }
 
 #retrieve a group from SCSM through the Cireson Web Portal API
@@ -3081,17 +3088,24 @@ function Get-CiresonPortalGroup
 
     $adGroup = Get-ADGroup @adParams -Filter "Mail -eq $groupEmail"
 
-    if($ciresonPortalWindowsAuth)
-    {
-        #wanted to use a get groups style request, but "api/V3/User/GetConsoleGroups" feels costly instead of a search
-        $cwpGroupResponse = Invoke-RestMethod -Uri ($ciresonPortalServer+"api/V3/User/GetUserList?userFilter=$($adGroup.Name)&filterByAnalyst=false&groupsOnly=true&maxNumberOfResults=25") -UseDefaultCredentials
+    try {
+        if($ciresonPortalWindowsAuth)
+        {
+            #wanted to use a get groups style request, but "api/V3/User/GetConsoleGroups" feels costly instead of a search
+            $cwpGroupResponse = Invoke-RestMethod -Uri ($ciresonPortalServer+"api/V3/User/GetUserList?userFilter=$($adGroup.Name)&filterByAnalyst=false&groupsOnly=true&maxNumberOfResults=25") -UseDefaultCredentials
+        }
+        else
+        {
+            $cwpGroupResponse = Invoke-RestMethod -Uri ($ciresonPortalServer+"api/V3/User/GetUserList?userFilter=$($adGroup.Name)&filterByAnalyst=false&groupsOnly=true&maxNumberOfResults=25") -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
+        }
+        $ciresonPortalGroup = $cwpGroupResponse | select-object @{Name='AccessGroupId'; Expression={$_.Id}}, name | Where-Object{$_.name -eq $($adGroup.Name)}
+        if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-CiresonPortalGroup" -EventID 0 -Severity Information -LogMessage "Group/Sender found in Cireson Portal"}
+        return $ciresonPortalGroup
     }
-    else
-    {
-        $cwpGroupResponse = Invoke-RestMethod -Uri ($ciresonPortalServer+"api/V3/User/GetUserList?userFilter=$($adGroup.Name)&filterByAnalyst=false&groupsOnly=true&maxNumberOfResults=25") -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
+    catch {
+        if ($loggingLevel -ge 3) {New-SMEXCOEvent -Source "Get-CiresonPortalGroup" -EventID 1 -Severity Error -LogMessage $_.Exception}
+        return $null
     }
-    $ciresonPortalGroup = $cwpGroupResponse | select-object @{Name='AccessGroupId'; Expression={$_.Id}}, name | Where-Object{$_.name -eq $($adGroup.Name)}
-    return $ciresonPortalGroup
 }
 
 #retrieve all the announcements on the portal
@@ -3128,36 +3142,47 @@ function Search-AvailableCiresonPortalOffering
     )
 
     $serviceCatalogAPIurl = "api/V3/ServiceCatalog/GetServiceCatalog?userId=$($ciresonPortalUser.id)&isScoped=$($ciresonPortalUser.Security.IsServiceCatalogScoped)"
-    if ($ciresonPortalWindowsAuth -eq $true)
-    {
-        $serviceCatalogResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$serviceCatalogAPIurl) -Method get -UseDefaultCredentials
-    }
-    else
-    {
-        $serviceCatalogResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$serviceCatalogAPIurl) -Method get -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
-    }
-
-    #### If the user has access to some Request Offerings, find which RO Titles/Description contain words from their original message ####
-    if ($serviceCatalogResults)
-    {
-        #prepare the results by generating a URL array for the email
-        $matchingRequestURLs = @()
-        foreach ($serviceCatalogResult in $serviceCatalogResults)
+    try {
+        if ($ciresonPortalWindowsAuth -eq $true)
         {
-            $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
-            if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToRO)
-            {
-                $ciresonPortalRequestURL = "`"" + $ciresonPortalServer + "SC/ServiceCatalog/RequestOffering/" + $serviceCatalogResult.RequestOfferingId + "," + $serviceCatalogResult.ServiceOfferingId + "`""
-                $RequestOfferingURL = "<a href=$ciresonPortalRequestURL/>$($serviceCatalogResult.RequestOfferingTitle)</a><br />"
-                $requestOfferingSuggestion = [PSCustomObject] @{
-                    RequestOfferingURL = $RequestOfferingURL
-                    WordsMatched       = $wordsMatched
-                }
-                $matchingRequestURLs += $requestOfferingSuggestion
-            }
+            $serviceCatalogResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$serviceCatalogAPIurl) -Method get -UseDefaultCredentials
         }
-        $matchingRequestURLs = ($matchingRequestURLs | sort-object WordsMatched -Descending).RequestOfferingURL
-        return $matchingRequestURLs
+        else
+        {
+            $serviceCatalogResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$serviceCatalogAPIurl) -Method get -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
+        }
+
+        #### If the user has access to some Request Offerings, find which RO Titles/Description contain words from their original message ####
+        if ($serviceCatalogResults)
+        {
+            #prepare the results by generating a URL array for the email
+            $matchingRequestURLs = @()
+            foreach ($serviceCatalogResult in $serviceCatalogResults)
+            {
+                $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
+                if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToRO)
+                {
+                    $ciresonPortalRequestURL = "`"" + $ciresonPortalServer + "SC/ServiceCatalog/RequestOffering/" + $serviceCatalogResult.RequestOfferingId + "," + $serviceCatalogResult.ServiceOfferingId + "`""
+                    $RequestOfferingURL = "<a href=$ciresonPortalRequestURL/>$($serviceCatalogResult.RequestOfferingTitle)</a><br />"
+                    $requestOfferingSuggestion = [PSCustomObject] @{
+                        RequestOfferingURL = $RequestOfferingURL
+                        WordsMatched       = $wordsMatched
+                    }
+                    $matchingRequestURLs += $requestOfferingSuggestion
+                }
+            }
+            $matchingRequestURLs = ($matchingRequestURLs | sort-object WordsMatched -Descending).RequestOfferingURL
+            if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Search-AvailableCiresonPortalOffering" -EventID 0 -Severity Information -LogMessage "$($matchingRequestURLs.Count) relevant ROs found"}
+            return $matchingRequestURLs
+        }
+        else {
+            if ($loggingLevel -ge 2) {New-SMEXCOEvent -Source "Search-AvailableCiresonPortalOffering" -EventID 1 -Severity Warning -LogMessage "No relevant ROs were found"}
+            return $null
+        }
+    }
+    catch {
+        if ($loggingLevel -ge 3) {New-SMEXCOEvent -Source "Search-AvailableCiresonPortalOffering" -EventID 2 -Severity Error -LogMessage $_.Exception}
+        return $null
     }
 }
 
@@ -3171,35 +3196,46 @@ function Search-CiresonKnowledgeBase
     )
 
     $kbAPIurl = "api/V3/Article/FullTextSearch?&searchValue=$searchQuery"
-    if ($ciresonPortalWindowsAuth -eq $true)
-    {
-        $kbResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$kbAPIurl) -UseDefaultCredentials
-    }
-    else
-    {
-        $kbResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$kbAPIurl) -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
-    }
-
-    $kbResults =  $kbResults | Where-Object{$_.endusercontent -ne ""} | select-object articleid, title
-
-    if ($kbResults)
-    {
-        $matchingKBURLs = @()
-        foreach ($kbResult in $kbResults)
+    try {
+        if ($ciresonPortalWindowsAuth -eq $true)
         {
-            $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($kbResult.title -match "\b$_\b")}).count
-            if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToKA)
-            {
-                $KnowledgeArticleURL = "<a href=$ciresonPortalServer" + "KnowledgeBase/View/$($kbResult.articleid)#/>$($kbResult.title)</a><br />"
-                $knowledgeSuggestion = [PSCustomObject] @{
-                    KnowledgeArticleURL = $KnowledgeArticleURL
-                    WordsMatched        = $wordsMatched
-                }
-                $matchingKBURLs += $knowledgeSuggestion
-            }
+            $kbResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$kbAPIurl) -UseDefaultCredentials
         }
-        $matchingKBURLs = ($matchingKBURLs | sort-object WordsMatched -Descending).KnowledgeArticleURL
-        return $matchingKBURLs
+        else
+        {
+            $kbResults = Invoke-RestMethod -Uri ($ciresonPortalServer+$kbAPIurl) -Headers @{"Authorization"=Get-CiresonPortalAPIToken}
+        }
+
+        $kbResults =  $kbResults | Where-Object{$_.endusercontent -ne ""} | select-object articleid, title
+
+        if ($kbResults)
+        {
+            $matchingKBURLs = @()
+            foreach ($kbResult in $kbResults)
+            {
+                $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($kbResult.title -match "\b$_\b")}).count
+                if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToKA)
+                {
+                    $KnowledgeArticleURL = "<a href=$ciresonPortalServer" + "KnowledgeBase/View/$($kbResult.articleid)#/>$($kbResult.title)</a><br />"
+                    $knowledgeSuggestion = [PSCustomObject] @{
+                        KnowledgeArticleURL = $KnowledgeArticleURL
+                        WordsMatched        = $wordsMatched
+                    }
+                    $matchingKBURLs += $knowledgeSuggestion
+                }
+            }
+            $matchingKBURLs = ($matchingKBURLs | sort-object WordsMatched -Descending).KnowledgeArticleURL
+            if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Search-CiresonKnowledgeBase" -EventID 0 -Severity Information -LogMessage "$($matchingKBURLs.Count) relevant KBs were found"}
+            return $matchingKBURLs
+        }
+        else {
+            if ($loggingLevel -ge 2) {New-SMEXCOEvent -Source "Search-CiresonKnowledgeBase" -EventID 1 -Severity Warning -LogMessage "No relevant KBs were found"}
+            return $null
+        }
+    }
+    catch {
+        if ($loggingLevel -ge 3) {New-SMEXCOEvent -Source "Search-CiresonKnowledgeBase" -EventID 2 -Severity Error -LogMessage $_.Exception}
+        return $null
     }
 }
 
@@ -3235,6 +3271,8 @@ function Get-CiresonSuggestionURL
     {
         return $null
     }
+
+    if ($loggingLevel -ge 4) {New-SMEXCOEvent -Source "Get-CiresonSuggestionURL" -EventID 0 -Severity Information -LogMessage "Retrieving Suggestion URLs from Cireson Portal. Suggest KA: $SuggestKA. SuggestRO: $SuggestRO."}
 
     #check string length
     $wiTitle = if ($WorkItem.title.length -ge 1) {$WorkItem.title.trim()} else {$null}

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2908,9 +2908,21 @@ function New-CMDBUser
         $domain = $domainAndTLD.Split(".")[0]
         $newID = $domain + "_" + $username + "_SMTP"
 
-        #create the new user
-        $newUser = New-SCSMObject -Class $domainUserClass -PropertyHashtable @{"domain" = "$domainAndTLD"; "username" = "$username"; "displayname" = "$userEmail"} @scsmMGMTParams -PassThru -NoCommit:$NoCommit
-        if (($loggingLevel -ge 1) -and ($newUser)){New-SMEXCOEvent -Source "New-CMDBUser" -EventId 0 -LogMessage "New User created in SCSM. Username: $username" -Severity "Information"}
+        #check if the user object already exists, then just add the mail address
+        $newUser = Get-SCSMObject -Class $domainUserClass -Filter "Username -eq '$username' -and Domain -eq '$domainAndTLD'" @scsmMGMTParams
+        if(!$newUser){
+            #create the new user
+            try{
+                $newUser = New-SCSMObject -Class $domainUserClass -PropertyHashtable @{"domain" = "$domainAndTLD"; "username" = "$username"; "displayname" = "$userEmail"} @scsmMGMTParams -PassThru -NoCommit:$NoCommit
+            }
+            catch {
+                New-SMEXCOEvent -Source "New-CMDBUser" -EventId 2 -LogMessage "Error creating user with username $username in SCSM: $($_)" -Severity "Error"
+            }
+            if (($loggingLevel -ge 1) -and ($newUser)){New-SMEXCOEvent -Source "New-CMDBUser" -EventId 0 -LogMessage "New User created in SCSM. Username: $username" -Severity "Information"}
+        }
+        else {
+            if (($loggingLevel -ge 1) -and ($newUser)){New-SMEXCOEvent -Source "New-CMDBUser" -EventId 3 -LogMessage "User already exists in SCSM. Will be updated with e-mail address. Username: $username" -Severity "Information"}
+        }
 
         #create the user notification projection
         $userNoticeProjection = @{__CLASS = "$($domainUserClass.Name)";

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3159,7 +3159,7 @@ function Search-AvailableCiresonPortalOffering
             $matchingRequestURLs = @()
             foreach ($serviceCatalogResult in $serviceCatalogResults)
             {
-                $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
+                $wordsMatched = ($searchQuery.Trim().Split() | ForEach-Object {[regex]::Escape($_)} | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
                 if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToRO)
                 {
                     $ciresonPortalRequestURL = "`"" + $ciresonPortalServer + "SC/ServiceCatalog/RequestOffering/" + $serviceCatalogResult.RequestOfferingId + "," + $serviceCatalogResult.ServiceOfferingId + "`""
@@ -3213,7 +3213,7 @@ function Search-CiresonKnowledgeBase
             $matchingKBURLs = @()
             foreach ($kbResult in $kbResults)
             {
-                $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($kbResult.title -match "\b$_\b")}).count
+                $wordsMatched = ($searchQuery.Trim().Split() | ForEach-Object {[regex]::Escape($_)} | Where-Object{($kbResult.title -match "\b$_\b")}).count
                 if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToKA)
                 {
                     $KnowledgeArticleURL = "<a href=$ciresonPortalServer" + "KnowledgeBase/View/$($kbResult.articleid)#/>$($kbResult.title)</a><br />"


### PR DESCRIPTION
**Describe the change**  
New-CMDBUser is called when an e-mail address cannot be found in SCSM, but if the username/domain combo already exists in SCSM but without the mail address the user creation will fail without an error message. This has happened to me a couple of times now, and is kind of hard to detect.

Added a simple check to see if the user object already exists before creation, and if the creation should fail for some reason, it will be logged as an error.