### PR TITLE
When suggesting KA/RO escape regex

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -3159,7 +3159,7 @@ function Search-AvailableCiresonPortalOffering
             $matchingRequestURLs = @()
             foreach ($serviceCatalogResult in $serviceCatalogResults)
             {
-                $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
+                $wordsMatched = ($searchQuery.Trim().Split() | ForEach-Object {[regex]::Escape($_)} | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
                 if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToRO)
                 {
                     $ciresonPortalRequestURL = "`"" + $ciresonPortalServer + "SC/ServiceCatalog/RequestOffering/" + $serviceCatalogResult.RequestOfferingId + "," + $serviceCatalogResult.ServiceOfferingId + "`""
@@ -3213,7 +3213,7 @@ function Search-CiresonKnowledgeBase
             $matchingKBURLs = @()
             foreach ($kbResult in $kbResults)
             {
-                $wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($kbResult.title -match "\b$_\b")}).count
+                $wordsMatched = ($searchQuery.Trim().Split() | ForEach-Object {[regex]::Escape($_)} | Where-Object{($kbResult.title -match "\b$_\b")}).count
                 if ($wordsMatched -ge $numberOfWordsToMatchFromEmailToKA)
                 {
                     $KnowledgeArticleURL = "<a href=$ciresonPortalServer" + "KnowledgeBase/View/$($kbResult.articleid)#/>$($kbResult.title)</a><br />"


### PR DESCRIPTION
Discovered an issue wherein if:
- Email is sent to the connector
- The email contains one or many signature graphics
- The signature graphic(s) have _alt text_ defined

The suggestions for that particular email will never return any results. This is due to the conversion from inline images to text that can be written into SCSM. Take the following an example, an email has a:
- **Subject** of "mobile issue"
- **Body** of "screen crack"
- Has a signature graphic with alt text of "corporate signature." If you right click on the message preview in Outlook, choose "View Source", then scroll down to find the inline image it will render something to the effect of:

```html
<img width=233 height=167 style='width:2.427in;height:1.7395in' id="Picture_x0020_1" src="cid:image001.jpg@01D9D51B.5DC75C80" alt="corporate signature">
```

But when this email is processed by the connector, the alt text property from the above is read and written into the new Work Item Description as:
```text
screen crack

[corporate signature]
```

When either Search-CiresonKnowledgeBase or Search-AvailablePortalOffering functions engage, an error will be produced to the effect of:

```text
System.ArgumentException: parsing "\b[corporate\b" - Unterminated [] set.
   at System.Text.RegularExpressions.RegexParser.ScanCharClass(Boolean caseInsensitive, Boolean scanOnly)
   at System.Text.RegularExpressions.RegexParser.CountCaptures()
   at System.Text.RegularExpressions.RegexParser.Parse(String re, RegexOptions op)
   at System.Text.RegularExpressions.Regex..ctor(String pattern, RegexOptions options, TimeSpan matchTimeout, Boolean useCache)
   at System.Text.RegularExpressions.Regex..ctor(String pattern, RegexOptions options)
   at System.Management.Automation.ParserOps.NewRegex(String patternString, RegexOptions options)
   at System.Management.Automation.ParserOps.MatchOperator(ExecutionContext context, IScriptExtent errorPosition, Object lval, Object rval, Boolean notMatch, Boolean ignoreCase)
   at System.Management.Automation.Interpreter.FuncCallInstruction`7.Run(InterpretedFrame frame)
   at System.Management.Automation.Interpreter.EnterTryCatchFinallyInstruction.Run(InterpretedFrame frame)
```

This is due to the the following lines seen in Search-CiresonKnowledgeBase and Search-AvailableCiresonPortalOffering functions:
```powershell
$wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($kbResult.title -match "\b$_\b")}).count
$wordsMatched = ($searchQuery.Trim().Split() | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
```

When this engages, the first result (from the $searchQuery.Trim().Split()) passed down the pipeline looks like:
```text
phone
issue
screen
crack
[corporate
signature]
```

By introducing a Foreach-Object on the pipeline that escapes relevant characters (known as a result of #453):
```powershell
$wordsMatched = ($searchQuery.Trim().Split() | ForEach-Object {[regex]::Escape($_)} | Where-Object{($kbResult.title -match "\b$_\b")}).count
$wordsMatched = ($searchQuery.Trim().Split() | ForEach-Object {[regex]::Escape($_)} | Where-Object{($serviceCatalogResult.RequestOfferingTitle -match "\b$_\b") -or ($serviceCatalogResult.RequestOfferingDescription -match "\b$_\b")}).count
```

the result now looks like:
```text
phone
issue
screen
crack
\[corporate
signature]
```

And the email will successfully trigger KA and/or RO suggestion URLs