### PR TITLE
MA: notes + comment to add

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2299,15 +2299,14 @@ function Update-WorkItem
                                         }
                                     }
                                     default {
-                                        $commentToAdd = $workItem.Notes + "$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n"
-                                        if ($commentToAdd.Length -gt 4000) {
+                                        if (($workItem.Notes + "$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n").Length -gt 4000) {
                                             if ($loggingLevel -ge 3) {
-                                                New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes and no further text will be added automatically by the Exchange connector. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
+                                                New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes and no further text will be added automatically by the SMLets Exchange connector. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
                                             }
                                             if ($ceScripts) { Invoke-AfterMANoteFailure }
                                         }
                                         else {
-                                            Set-SCSMObject -SMObject $workItem -PropertyHashtable @{"Notes" = $commentToAdd} @scsmMGMTParams
+                                            Set-SCSMObject -SMObject $workItem -PropertyHashtable @{"Notes" = "$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n"} @scsmMGMTParams
                                         }
                                     }
                                 }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2299,7 +2299,16 @@ function Update-WorkItem
                                         }
                                     }
                                     default {
-                                        Set-SCSMObject -SMObject $workItem -PropertyHashtable @{"Notes" = "$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n"} @scsmMGMTParams
+                                        $commentToAdd = $workItem.Notes + "$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n"
+                                        if ($commentToAdd.Length -gt 4000) {
+                                            if ($loggingLevel -ge 3) {
+                                                New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes and no further text will be added automatically by the Exchange connector. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
+                                            }
+                                            if ($ceScripts) { Invoke-AfterMANoteFailure }
+                                        }
+                                        else {
+                                            Set-SCSMObject -SMObject $workItem -PropertyHashtable @{"Notes" = $commentToAdd} @scsmMGMTParams
+                                        }
                                     }
                                 }
                             }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2301,7 +2301,7 @@ function Update-WorkItem
                                     default {
                                         if (("$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n").Length -gt 4000) {
                                             if ($loggingLevel -ge 3) {
-                                                New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes and no further text will be added automatically by the SMLets Exchange Connector. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
+                                                New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
                                             }
                                             if ($ceScripts) { Invoke-AfterMANoteFailure }
                                         }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2301,7 +2301,7 @@ function Update-WorkItem
                                     default {
                                         if (("$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n").Length -gt 4000) {
                                             if ($loggingLevel -ge 3) {
-                                                New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes and no further text will be added automatically by the SMLets Exchange connector. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
+                                                New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes and no further text will be added automatically by the SMLets Exchange Connector. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
                                             }
                                             if ($ceScripts) { Invoke-AfterMANoteFailure }
                                         }

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -2299,7 +2299,7 @@ function Update-WorkItem
                                         }
                                     }
                                     default {
-                                        if (($workItem.Notes + "$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n").Length -gt 4000) {
+                                        if (("$($workItem.Notes)$($commentLeftBy.Name) @ $(get-date): $commentToAdd `n").Length -gt 4000) {
                                             if ($loggingLevel -ge 3) {
                                                 New-SMEXCOEvent -Source "Update-WorkItem" -EventId 14 -Severity "Error" -LogMessage "Activity notes entry is too long. Max total length is 4000 characters. This text has not been added to the activity notes and no further text will be added automatically by the SMLets Exchange connector. If you would like to alter this behavior, modify the Invoke-AfterMANoteFailure Custom Event."
                                             }

--- a/smletsExchangeConnector_customEvents.ps1
+++ b/smletsExchangeConnector_customEvents.ps1
@@ -327,3 +327,8 @@ function Invoke-CustomRuleAction {
   #>
 
 }
+
+function Invoke-AfterMANoteFailure {
+  # This function occurs after an attempt was made to add a Comment to a Manual Activity whose Notes + Comment to Add exceed 4,000 characters.
+  
+}


### PR DESCRIPTION
When a Comment is added to a Manual Activity that is not a keyword, the current Notes + the Comment to Add's length could exceed the maximum allowable 4,000 characters of the Notes field. This change:
- Always check the current notes + comment's total length to ensure it fits within 4000 characters
- Logs an error similar to the stock exchange connector
- Includes support for a Custom Event to override this behavior