### PR TITLE
handle inline attachments

### DIFF
--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -5282,7 +5282,7 @@ foreach ($message in $inbox)
             ItemClass           = $message.ItemClass
         }
 
-        #if we have the HasAttachments property and we're using Exchange Online/Graph. Call graph for attachments and set them in the existing property
+        #Call graph for attachments and set them in the existing property
         if ($UseExchangeOnline) {
             $attachmentEndpoint = Invoke-RestMethod -uri "https://$azureSubdomain.microsoft.$azureTLD/v1.0/me/messages/$($email.ID)/attachments" -Headers @{Authorization = "Bearer $($tokenReqResponse.access_token)" }
             $email.Attachments = $attachmentEndpoint.value
@@ -5356,7 +5356,7 @@ foreach ($message in $inbox)
             ItemClass         = $message.ItemClass
         }
 
-        #if we have the HasAttachments property and we're using Exchange Online/Graph. Call graph for attachments and set them in the existing property
+        #Call graph for attachments and set them in the existing property
         if ($UseExchangeOnline) {
             $attachmentEndpoint = Invoke-RestMethod -uri "https://$azureSubdomain.microsoft.$azureTLD/v1.0/me/messages/$($email.ID)/attachments" -Headers @{Authorization = "Bearer $($tokenReqResponse.access_token)" }
             $email.Attachments = $attachmentEndpoint.value

--- a/smletsExchangeConnector.ps1
+++ b/smletsExchangeConnector.ps1
@@ -5283,7 +5283,7 @@ foreach ($message in $inbox)
         }
 
         #if we have the HasAttachments property and we're using Exchange Online/Graph. Call graph for attachments and set them in the existing property
-        if ($message.HasAttachments -and $UseExchangeOnline) {
+        if ($UseExchangeOnline) {
             $attachmentEndpoint = Invoke-RestMethod -uri "https://$azureSubdomain.microsoft.$azureTLD/v1.0/me/messages/$($email.ID)/attachments" -Headers @{Authorization = "Bearer $($tokenReqResponse.access_token)" }
             $email.Attachments = $attachmentEndpoint.value
         }
@@ -5357,7 +5357,7 @@ foreach ($message in $inbox)
         }
 
         #if we have the HasAttachments property and we're using Exchange Online/Graph. Call graph for attachments and set them in the existing property
-        if ($message.HasAttachments -and $UseExchangeOnline) {
+        if ($UseExchangeOnline) {
             $attachmentEndpoint = Invoke-RestMethod -uri "https://$azureSubdomain.microsoft.$azureTLD/v1.0/me/messages/$($email.ID)/attachments" -Headers @{Authorization = "Bearer $($tokenReqResponse.access_token)" }
             $email.Attachments = $attachmentEndpoint.value
         }


### PR DESCRIPTION
the HasAttachments property for Graph messages does not honor inline attachments. Removing part of this check to ensure attachments regardless of where they are on a message are always attempted to be retrieved when using Exchange Online